### PR TITLE
Updating Native Text Token Font Families

### DIFF
--- a/dist/json/android.json
+++ b/dist/json/android.json
@@ -1838,7 +1838,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "cdr_text_default_display_1_font_family",
       "attributes": {
         "option": false,
@@ -1867,7 +1867,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "cdr_text_default_title_1_font_family",
       "attributes": {
         "option": false,
@@ -1896,7 +1896,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "cdr_text_default_title_2_font_family",
       "attributes": {
         "option": false,
@@ -1925,7 +1925,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "cdr_text_default_title_3_font_family",
       "attributes": {
         "option": false,
@@ -1954,7 +1954,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "cdr_text_default_headline_font_family",
       "attributes": {
         "option": false,
@@ -1983,7 +1983,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "cdr_text_default_subheadline_font_family",
       "attributes": {
         "option": false,
@@ -2012,7 +2012,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "cdr_text_default_body_1_font_family",
       "attributes": {
         "option": false,
@@ -2041,7 +2041,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "cdr_text_default_body_2_font_family",
       "attributes": {
         "option": false,
@@ -2070,7 +2070,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "cdr_text_default_caption_1_font_family",
       "attributes": {
         "option": false,
@@ -2099,7 +2099,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "cdr_text_default_caption_2_font_family",
       "attributes": {
         "option": false,
@@ -2128,7 +2128,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "cdr_text_default_button_font_family",
       "attributes": {
         "option": false,

--- a/dist/json/ios.json
+++ b/dist/json/ios.json
@@ -1838,7 +1838,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "CdrTextDefaultDisplay1FontFamily",
       "attributes": {
         "option": false,
@@ -1867,7 +1867,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "CdrTextDefaultTitle1FontFamily",
       "attributes": {
         "option": false,
@@ -1896,7 +1896,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "CdrTextDefaultTitle2FontFamily",
       "attributes": {
         "option": false,
@@ -1925,7 +1925,7 @@
       }
     },
     {
-      "value": "Sentinel-Semibold.otf",
+      "value": "REI-Stuart-App-Semibold.otf",
       "name": "CdrTextDefaultTitle3FontFamily",
       "attributes": {
         "option": false,
@@ -1954,7 +1954,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "CdrTextDefaultHeadlineFontFamily",
       "attributes": {
         "option": false,
@@ -1983,7 +1983,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "CdrTextDefaultSubheadlineFontFamily",
       "attributes": {
         "option": false,
@@ -2012,7 +2012,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "CdrTextDefaultBody1FontFamily",
       "attributes": {
         "option": false,
@@ -2041,7 +2041,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "CdrTextDefaultBody2FontFamily",
       "attributes": {
         "option": false,
@@ -2070,7 +2070,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "CdrTextDefaultCaption1FontFamily",
       "attributes": {
         "option": false,
@@ -2099,7 +2099,7 @@
       }
     },
     {
-      "value": "Roboto-Regular.ttf",
+      "value": "Graphik-App-Regular.ttf",
       "name": "CdrTextDefaultCaption2FontFamily",
       "attributes": {
         "option": false,
@@ -2128,7 +2128,7 @@
       }
     },
     {
-      "value": "Roboto-Medium.ttf",
+      "value": "Graphik-App-Medium.ttf",
       "name": "CdrTextDefaultButtonFontFamily",
       "attributes": {
         "option": false,

--- a/dist/json/platform-tokens.json
+++ b/dist/json/platform-tokens.json
@@ -3303,7 +3303,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "cdr_text_default_display_1_font_family",
         "attributes": {
           "option": false,
@@ -3332,7 +3332,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "cdr_text_default_title_1_font_family",
         "attributes": {
           "option": false,
@@ -3361,7 +3361,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "cdr_text_default_title_2_font_family",
         "attributes": {
           "option": false,
@@ -3390,7 +3390,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "cdr_text_default_title_3_font_family",
         "attributes": {
           "option": false,
@@ -3419,7 +3419,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "cdr_text_default_headline_font_family",
         "attributes": {
           "option": false,
@@ -3448,7 +3448,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "cdr_text_default_subheadline_font_family",
         "attributes": {
           "option": false,
@@ -3477,7 +3477,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "cdr_text_default_body_1_font_family",
         "attributes": {
           "option": false,
@@ -3506,7 +3506,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "cdr_text_default_body_2_font_family",
         "attributes": {
           "option": false,
@@ -3535,7 +3535,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "cdr_text_default_caption_1_font_family",
         "attributes": {
           "option": false,
@@ -3564,7 +3564,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "cdr_text_default_caption_2_font_family",
         "attributes": {
           "option": false,
@@ -3593,7 +3593,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "cdr_text_default_button_font_family",
         "attributes": {
           "option": false,
@@ -3634,7 +3634,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "CdrTextDefaultDisplay1FontFamily",
         "attributes": {
           "option": false,
@@ -3663,7 +3663,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "CdrTextDefaultTitle1FontFamily",
         "attributes": {
           "option": false,
@@ -3692,7 +3692,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "CdrTextDefaultTitle2FontFamily",
         "attributes": {
           "option": false,
@@ -3721,7 +3721,7 @@
         }
       },
       {
-        "value": "Sentinel-Semibold.otf",
+        "value": "REI-Stuart-App-Semibold.otf",
         "name": "CdrTextDefaultTitle3FontFamily",
         "attributes": {
           "option": false,
@@ -3750,7 +3750,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "CdrTextDefaultHeadlineFontFamily",
         "attributes": {
           "option": false,
@@ -3779,7 +3779,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "CdrTextDefaultSubheadlineFontFamily",
         "attributes": {
           "option": false,
@@ -3808,7 +3808,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "CdrTextDefaultBody1FontFamily",
         "attributes": {
           "option": false,
@@ -3837,7 +3837,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "CdrTextDefaultBody2FontFamily",
         "attributes": {
           "option": false,
@@ -3866,7 +3866,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "CdrTextDefaultCaption1FontFamily",
         "attributes": {
           "option": false,
@@ -3895,7 +3895,7 @@
         }
       },
       {
-        "value": "Roboto-Regular.ttf",
+        "value": "Graphik-App-Regular.ttf",
         "name": "CdrTextDefaultCaption2FontFamily",
         "attributes": {
           "option": false,
@@ -3924,7 +3924,7 @@
         }
       },
       {
-        "value": "Roboto-Medium.ttf",
+        "value": "Graphik-App-Medium.ttf",
         "name": "CdrTextDefaultButtonFontFamily",
         "attributes": {
           "option": false,

--- a/tokens/mobile/text.json5
+++ b/tokens/mobile/text.json5
@@ -12,7 +12,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Medium.ttf'
+          value: 'Graphik-App-Medium.ttf'
         }
       },
       // Title 1
@@ -26,7 +26,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Sentinel-Semibold.otf'
+          value: 'REI-Stuart-App-Semibold.otf'
         }
       },
       // Title 2
@@ -40,7 +40,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Sentinel-Semibold.otf'
+          value: 'REI-Stuart-App-Semibold.otf'
         }
       },
       // Title 3
@@ -54,7 +54,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Sentinel-Semibold.otf'
+          value: 'REI-Stuart-App-Semibold.otf'
         }
       },
       // Headline
@@ -68,7 +68,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Medium.ttf'
+          value: 'Graphik-App-Medium.ttf'
         }
       },
       // Subheadline
@@ -82,7 +82,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Medium.ttf'
+          value: 'Graphik-App-Medium.ttf'
         }
       },
       // Body 1
@@ -96,7 +96,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Regular.ttf'
+          value: 'Graphik-App-Regular.ttf'
         }
       },
       // Body 2
@@ -110,7 +110,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Regular.ttf'
+          value: 'Graphik-App-Regular.ttf'
         }
       },
       // Caption 1
@@ -124,7 +124,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Regular.ttf'
+          value: 'Graphik-App-Regular.ttf'
         }
       },
       // Caption 2
@@ -138,7 +138,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Regular.ttf'
+          value: 'Graphik-App-Regular.ttf'
         }
       },
       // Button
@@ -152,7 +152,7 @@
           category: 'size'
         },
         'font-family': {
-          value: 'Roboto-Medium.ttf'
+          value: 'Graphik-App-Medium.ttf'
         }
       }
     }


### PR DESCRIPTION
Did a 1:1 replacement of `Roboto` with `Graphic-App` and `Sentinel` with `Stuart-App`. This will get us 80% of what we want. The sizes, and line-heights should be updated too, but we can handle that later.

@KrisKnabel,
I have a zip with all the .ttf versions in the changes here. I will slack them over to you in a link. I could also just submit a PR to the native branches replacing the old font .ttf files with the new ones. Whatever you need. 

@fesnaqvi and I will update the CDR Native Toolkit to match this change...