### PR TITLE
sr-only and container mixins

### DIFF
--- a/dist/less/cdr-tokens.less
+++ b/dist/less/cdr-tokens.less
@@ -1557,8 +1557,30 @@
 @cdr-text-utility-serif-strong-800-spacing: -0.16px;
 @cdr-text-utility-serif-strong-800-size: 3.2rem;
 @cdr-text-utility-serif-strong-800-height: 4rem;
-// DON'T MOVE THIS FILE
-// It will be copied into `dist`
+.cdr-display-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.cdr-display-sr-focusable {
+  .cdr-display-sr-only();
+
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}
 
 // XS
 .cdr-xs-mq(@rules) {

--- a/dist/less/cdr-tokens.less
+++ b/dist/less/cdr-tokens.less
@@ -1582,6 +1582,31 @@
   }
 }
 
+.cdr-container-fluid-base-mixin {
+  padding-left: @cdr-space-one-x;
+  padding-right: @cdr-space-one-x;
+  width: 100%;
+}
+
+.cdr-container-fluid-medium-mixin {
+  padding-left: @cdr-space-two-x;
+  padding-right: @cdr-space-two-x;
+}
+
+.cdr-container-base-mixin {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: @cdr-space-one-x;
+  padding-right: @cdr-space-one-x;
+  width: 100%;
+  max-width: @cdr-breakpoint-lg;
+}
+
+.cdr-container-medium-mixin {
+  padding-left: @cdr-space-two-x;
+  padding-right: @cdr-space-two-x;
+}
+
 // XS
 .cdr-xs-mq(@rules) {
   @media (min-width: @cdr-breakpoint-xs) {

--- a/dist/scss/cdr-tokens.scss
+++ b/dist/scss/cdr-tokens.scss
@@ -1641,6 +1641,56 @@ $cdr-text-utility-serif-strong-800-height: 4rem;
   }
 }
 
+@mixin cdr-container-fluid-base-mixin() {
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+}
+
+@mixin cdr-container-fluid-medium-mixin() {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+%cdr-container-fluid-base-mixin {
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+}
+
+%cdr-container-fluid-medium-mixin {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+@mixin cdr-container-base-mixin() {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+  max-width: $cdr-breakpoint-lg;
+}
+
+@mixin cdr-container-medium-mixin() {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+%cdr-container-base-mixin {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+  max-width: $cdr-breakpoint-lg;
+}
+
+%cdr-container-medium-mixin {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
 // XS
 @mixin cdr-xs-mq {
   @media (min-width: #{$cdr-breakpoint-xs}) {

--- a/dist/scss/cdr-tokens.scss
+++ b/dist/scss/cdr-tokens.scss
@@ -1593,8 +1593,53 @@ $cdr-text-utility-serif-strong-800-weight: 600;
 $cdr-text-utility-serif-strong-800-spacing: -0.16px;
 $cdr-text-utility-serif-strong-800-size: 3.2rem;
 $cdr-text-utility-serif-strong-800-height: 4rem;
-// DON'T MOVE THIS FILE
-// It will be copied into `dist`
+@mixin cdr-display-sr-only() {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+%cdr-display-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@mixin cdr-display-sr-focusable () {
+  @include cdr-display-sr-only;
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}
+
+%cdr-display-sr-focusable {
+  @include cdr-display-sr-only;
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}
 
 // XS
 @mixin cdr-xs-mq {

--- a/style-dictionary/actions/include_display_less.js
+++ b/style-dictionary/actions/include_display_less.js
@@ -1,0 +1,17 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+module.exports = (StyleDictionary) => {
+  // concat all files in buildPath to a given filename
+  StyleDictionary.registerAction({
+    name: 'include_display_less',
+    do(dictionary, config) {
+      const less = path.join(__dirname, '../utilities/display.less');
+      const outputDir = path.join(__dirname, '../../', config.buildPath, 'display.less');
+      fs.copyFileSync(less, outputDir);
+    },
+    undo(dictionary, config) {
+      fs.removeSync(path.join(__dirname, '../../', config.buildPath));
+    },
+  });
+};

--- a/style-dictionary/actions/include_display_scss.js
+++ b/style-dictionary/actions/include_display_scss.js
@@ -1,0 +1,17 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+module.exports = (StyleDictionary) => {
+  // concat all files in buildPath to a given filename
+  StyleDictionary.registerAction({
+    name: 'include_display_scss',
+    do(dictionary, config) {
+      const scss = path.join(__dirname, '../utilities/display.scss');
+      const outputDir = path.join(__dirname, '../../', config.buildPath, 'display.scss');
+      fs.copyFileSync(scss, outputDir);
+    },
+    undo(dictionary, config) {
+      fs.removeSync(path.join(__dirname, '../../', config.buildPath));
+    },
+  });
+};

--- a/style-dictionary/build.js
+++ b/style-dictionary/build.js
@@ -34,6 +34,8 @@ require('./actions/concat_files')(StyleDictionary);
 require('./actions/include_deprecate_scss')(StyleDictionary);
 require('./actions/include_media_queries_scss')(StyleDictionary);
 require('./actions/include_media_queries_less')(StyleDictionary);
+require('./actions/include_display_scss')(StyleDictionary);
+require('./actions/include_display_less')(StyleDictionary);
 
 // --------------------------------------------------------------------
 

--- a/style-dictionary/configs/less.js
+++ b/style-dictionary/configs/less.js
@@ -13,6 +13,6 @@ module.exports = {
         format: 'less/mixin',
       },
     ],
-    actions: ['include_media_queries_less', 'concat_files'],
+    actions: ['include_media_queries_less', 'include_display_less', 'concat_files'],
   },
 };

--- a/style-dictionary/configs/scss.js
+++ b/style-dictionary/configs/scss.js
@@ -21,6 +21,6 @@ module.exports = {
         format: 'scss/map',
       },
     ],
-    actions: ['include_media_queries_scss', 'concat_files', 'include_deprecate_scss'],
+    actions: ['include_media_queries_scss', 'include_display_scss', 'concat_files', 'include_deprecate_scss'],
   },
 };

--- a/style-dictionary/utilities/display.less
+++ b/style-dictionary/utilities/display.less
@@ -1,0 +1,24 @@
+.cdr-display-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.cdr-display-sr-focusable {
+  .cdr-display-sr-only();
+
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}

--- a/style-dictionary/utilities/display.less
+++ b/style-dictionary/utilities/display.less
@@ -22,3 +22,28 @@
     clip: auto;
   }
 }
+
+.cdr-container-fluid-base-mixin {
+  padding-left: @cdr-space-one-x;
+  padding-right: @cdr-space-one-x;
+  width: 100%;
+}
+
+.cdr-container-fluid-medium-mixin {
+  padding-left: @cdr-space-two-x;
+  padding-right: @cdr-space-two-x;
+}
+
+.cdr-container-base-mixin {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: @cdr-space-one-x;
+  padding-right: @cdr-space-one-x;
+  width: 100%;
+  max-width: @cdr-breakpoint-lg;
+}
+
+.cdr-container-medium-mixin {
+  padding-left: @cdr-space-two-x;
+  padding-right: @cdr-space-two-x;
+}

--- a/style-dictionary/utilities/display.scss
+++ b/style-dictionary/utilities/display.scss
@@ -45,3 +45,53 @@
     clip: auto;
   }
 }
+
+@mixin cdr-container-fluid-base-mixin() {
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+}
+
+@mixin cdr-container-fluid-medium-mixin() {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+%cdr-container-fluid-base-mixin {
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+}
+
+%cdr-container-fluid-medium-mixin {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+@mixin cdr-container-base-mixin() {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+  max-width: $cdr-breakpoint-lg;
+}
+
+@mixin cdr-container-medium-mixin() {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}
+
+%cdr-container-base-mixin {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $cdr-space-one-x;
+  padding-right: $cdr-space-one-x;
+  width: 100%;
+  max-width: $cdr-breakpoint-lg;
+}
+
+%cdr-container-medium-mixin {
+  padding-left: $cdr-space-two-x;
+  padding-right: $cdr-space-two-x;
+}

--- a/style-dictionary/utilities/display.scss
+++ b/style-dictionary/utilities/display.scss
@@ -1,0 +1,47 @@
+@mixin cdr-display-sr-only() {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+%cdr-display-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@mixin cdr-display-sr-focusable () {
+  @include cdr-display-sr-only;
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}
+
+%cdr-display-sr-focusable {
+  @include cdr-display-sr-only;
+  &:hover,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}

--- a/style-dictionary/utilities/media-queries.less
+++ b/style-dictionary/utilities/media-queries.less
@@ -1,6 +1,3 @@
-// DON'T MOVE THIS FILE
-// It will be copied into `dist`
-
 // XS
 .cdr-xs-mq(@rules) {
   @media (min-width: @cdr-breakpoint-xs) {

--- a/style-dictionary/utilities/media-queries.scss
+++ b/style-dictionary/utilities/media-queries.scss
@@ -1,6 +1,3 @@
-// DON'T MOVE THIS FILE
-// It will be copied into `dist`
-
 // XS
 @mixin cdr-xs-mq {
   @media (min-width: #{$cdr-breakpoint-xs}) {


### PR DESCRIPTION
- adds sr-only and container mixins to cdr-tokens so consumers can skip loading those utility class files
- the rest of the cedar utilities are either already represented by a token/mixin, or are just encoding basic HTML values (i.e, `display: block`) and can easily be replicated by consumers.