### PR TITLE
fix naming of container mixins, add utility mixins to docs

### DIFF
--- a/dist/json/platform-tokens.json
+++ b/dist/json/platform-tokens.json
@@ -8017,6 +8017,132 @@
     ]
   },
   "web": {
+    "display": [
+      {
+        "value": "Mixin for screen readers only",
+        "category": "display",
+        "name": "cdr-display-sr-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      },
+      {
+        "value": "Mixin for screen readers only, but remains focusable",
+        "category": "display",
+        "name": "cdr-display-sr-only-focusable",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      }
+    ],
+    "container": [
+      {
+        "value": "Mixin for wrapping page content",
+        "category": "container",
+        "name": "cdr-container",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      },
+      {
+        "value": "Mixin for wrapping page content responsively",
+        "category": "container",
+        "name": "cdr-container-fluid",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      }
+    ],
+    "media-query": [
+      {
+        "value": "Mixin content rendered at extra small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-xs-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at extra small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-xs-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-sm-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-sm-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at medium breakpoint only",
+        "category": "media-query",
+        "name": "cdr-md-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at medium breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-md-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at large breakpoint only",
+        "category": "media-query",
+        "name": "cdr-lg-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at large breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-lg-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      }
+    ],
     "colors": [],
     "sizing": [],
     "motion": [],

--- a/dist/scss/cdr-tokens.scss
+++ b/dist/scss/cdr-tokens.scss
@@ -1641,54 +1641,27 @@ $cdr-text-utility-serif-strong-800-height: 4rem;
   }
 }
 
-@mixin cdr-container-fluid-base-mixin() {
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-}
-
-@mixin cdr-container-fluid-medium-mixin() {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-%cdr-container-fluid-base-mixin {
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-}
-
-%cdr-container-fluid-medium-mixin {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-@mixin cdr-container-base-mixin() {
+@mixin cdr-container {
   margin-left: auto;
   margin-right: auto;
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
   max-width: $cdr-breakpoint-lg;
+  @include cdr-md-mq {
+    padding-left: $cdr-space-two-x;
+    padding-right: $cdr-space-two-x;
+  }
 }
 
-@mixin cdr-container-medium-mixin() {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-%cdr-container-base-mixin {
-  margin-left: auto;
-  margin-right: auto;
+@mixin cdr-container-fluid {
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
-  max-width: $cdr-breakpoint-lg;
-}
-
-%cdr-container-medium-mixin {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
+  @include cdr-md-mq {
+    padding-left: $cdr-space-two-x;
+    padding-right: $cdr-space-two-x;
+  }
 }
 
 // XS

--- a/docs/src/assets/cdr-tokens.json
+++ b/docs/src/assets/cdr-tokens.json
@@ -8017,6 +8017,132 @@
     ]
   },
   "web": {
+    "display": [
+      {
+        "value": "Mixin for screen readers only",
+        "category": "display",
+        "name": "cdr-display-sr-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      },
+      {
+        "value": "Mixin for screen readers only, but remains focusable",
+        "category": "display",
+        "name": "cdr-display-sr-only-focusable",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      }
+    ],
+    "container": [
+      {
+        "value": "Mixin for wrapping page content",
+        "category": "container",
+        "name": "cdr-container",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      },
+      {
+        "value": "Mixin for wrapping page content responsively",
+        "category": "container",
+        "name": "cdr-container-fluid",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      }
+    ],
+    "media-query": [
+      {
+        "value": "Mixin content rendered at extra small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-xs-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at extra small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-xs-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-sm-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-sm-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at medium breakpoint only",
+        "category": "media-query",
+        "name": "cdr-md-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at medium breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-md-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at large breakpoint only",
+        "category": "media-query",
+        "name": "cdr-lg-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered at large breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-lg-mq",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      }
+    ],
     "colors": [],
     "sizing": [],
     "motion": [],

--- a/siteTokens.js
+++ b/siteTokens.js
@@ -4,6 +4,7 @@ const rawGlobal = require('./dist/json/global.json');
 const rawWeb = require('./dist/json/web.json');
 const rawAndroid = require('./dist/json/android.json');
 const rawIos = require('./dist/json/ios.json');
+const utilities = require('./style-dictionary/utilities/utilities.json');
 
 // get keys for each category per platform
 const globalKeyArr = Object.keys(rawGlobal);
@@ -23,7 +24,7 @@ const allKeys = _.union(globalKeyArr, webKeyArr, androidKeyArr, iosKeyArr);
 
 const dataByPlatform = {
   global: {},
-  web: {},
+  web: utilities,
   android: {},
   ios: {},
 };

--- a/style-dictionary/utilities/display.scss
+++ b/style-dictionary/utilities/display.scss
@@ -46,52 +46,25 @@
   }
 }
 
-@mixin cdr-container-fluid-base-mixin() {
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-}
-
-@mixin cdr-container-fluid-medium-mixin() {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-%cdr-container-fluid-base-mixin {
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-}
-
-%cdr-container-fluid-medium-mixin {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-@mixin cdr-container-base-mixin() {
+@mixin cdr-container {
   margin-left: auto;
   margin-right: auto;
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
   max-width: $cdr-breakpoint-lg;
+  @include cdr-md-mq {
+    padding-left: $cdr-space-two-x;
+    padding-right: $cdr-space-two-x;
+  }
 }
 
-@mixin cdr-container-medium-mixin() {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
-}
-
-%cdr-container-base-mixin {
-  margin-left: auto;
-  margin-right: auto;
+@mixin cdr-container-fluid {
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
-  max-width: $cdr-breakpoint-lg;
-}
-
-%cdr-container-medium-mixin {
-  padding-left: $cdr-space-two-x;
-  padding-right: $cdr-space-two-x;
+  @include cdr-md-mq {
+    padding-left: $cdr-space-two-x;
+    padding-right: $cdr-space-two-x;
+  }
 }

--- a/style-dictionary/utilities/utilities.json
+++ b/style-dictionary/utilities/utilities.json
@@ -1,0 +1,128 @@
+{
+  "display": [
+    {
+      "value": "Mixin for screen readers only",
+      "category": "display",
+      "name": "cdr-display-sr-only",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "display"
+      }
+    },
+    {
+      "value": "Mixin for screen readers only, but remains focusable",
+      "category": "display",
+      "name": "cdr-display-sr-only-focusable",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "display"
+      }
+    }
+  ],
+  "container": [
+    {
+      "value": "Mixin for wrapping page content",
+      "category": "container",
+      "name": "cdr-container",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "container"
+      }
+    },
+    {
+      "value": "Mixin for wrapping page content responsively",
+      "category": "container",
+      "name": "cdr-container-fluid",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "container"
+      }
+    }
+  ],
+  "media-query": [
+    {
+      "value": "Mixin content rendered at extra small breakpoint only",
+      "category": "media-query",
+      "name": "cdr-xs-mq-only",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at extra small breakpoint and above",
+      "category": "media-query",
+      "name": "cdr-xs-mq",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at small breakpoint only",
+      "category": "media-query",
+      "name": "cdr-sm-mq-only",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at small breakpoint and above",
+      "category": "media-query",
+      "name": "cdr-sm-mq",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at medium breakpoint only",
+      "category": "media-query",
+      "name": "cdr-md-mq-only",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at medium breakpoint and above",
+      "category": "media-query",
+      "name": "cdr-md-mq",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at large breakpoint only",
+      "category": "media-query",
+      "name": "cdr-lg-mq-only",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    },
+    {
+      "value": "Mixin content rendered at large breakpoint and above",
+      "category": "media-query",
+      "name": "cdr-lg-mq",
+      "attributes": {
+        "option": false,
+        "deprecated": false,
+        "category": "media-query"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- deleting base/medium container mixins and just replacing with mixins that have the media query built in. Doesn't make much sense to require consumers to do that manually.
- adds media query, container, and sr-only mixins to tokens data object so they'll be documented on the tokens gh-page and the all-tokens page on the doc site.