### PR TITLE
add mixins for cdr-text-italic/strong

### DIFF
--- a/dist/js/cdr-tokens.common.js
+++ b/dist/js/cdr-tokens.common.js
@@ -828,4 +828,7 @@ module.exports = {
   cdrTextUtilitySerifStrong800Spacing: "-0.16",
   cdrTextUtilitySerifStrong800Size: "32",
   cdrTextUtilitySerifStrong800Height: "40",
+  cdrTextItalicVariation: "'ital' 1",
+  cdrTextItalicStyle: "italic",
+  cdrTextStrongWeight: "700",
 };

--- a/dist/js/cdr-tokens.esm.js
+++ b/dist/js/cdr-tokens.esm.js
@@ -827,3 +827,6 @@ export const CdrTextUtilitySerifStrong800Weight = "600";
 export const CdrTextUtilitySerifStrong800Spacing = "-0.16";
 export const CdrTextUtilitySerifStrong800Size = "32";
 export const CdrTextUtilitySerifStrong800Height = "40";
+export const CdrTextItalicVariation = "'ital' 1";
+export const CdrTextItalicStyle = "italic";
+export const CdrTextStrongWeight = "700";

--- a/dist/json/platform-tokens.json
+++ b/dist/json/platform-tokens.json
@@ -22305,6 +22305,81 @@
           "deprecated": false,
           "category": "size"
         }
+      },
+      {
+        "value": "'ital' 1",
+        "mixin": "cdr-textItalic",
+        "property": "font-variation-settings",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        },
+        "original": {
+          "value": "'ital' 1",
+          "mixin": "textItalic",
+          "property": "font-variation-settings",
+          "docs": {
+            "category": "text",
+            "type": "default",
+            "example": "text"
+          }
+        },
+        "name": "cdr-text-italic-variation",
+        "attributes": {
+          "option": false,
+          "deprecated": false
+        }
+      },
+      {
+        "value": "italic",
+        "mixin": "cdr-textItalic",
+        "property": "font-style",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        },
+        "original": {
+          "value": "italic",
+          "mixin": "textItalic",
+          "property": "font-style",
+          "docs": {
+            "category": "text",
+            "type": "default",
+            "example": "text"
+          }
+        },
+        "name": "cdr-text-italic-style",
+        "attributes": {
+          "option": false,
+          "deprecated": false
+        }
+      },
+      {
+        "value": "700",
+        "mixin": "cdr-textStrong",
+        "property": "font-weight",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        },
+        "original": {
+          "value": "{options.font.weight.strong.value}",
+          "mixin": "textStrong",
+          "property": "font-weight",
+          "docs": {
+            "category": "text",
+            "type": "default",
+            "example": "text"
+          }
+        },
+        "name": "cdr-text-strong-weight",
+        "attributes": {
+          "option": false,
+          "deprecated": false
+        }
       }
     ],
     "breakpoints": [

--- a/dist/json/web.json
+++ b/dist/json/web.json
@@ -19456,6 +19456,81 @@
         "deprecated": false,
         "category": "size"
       }
+    },
+    {
+      "value": "'ital' 1",
+      "mixin": "cdr-textItalic",
+      "property": "font-variation-settings",
+      "docs": {
+        "category": "text",
+        "type": "default",
+        "example": "text"
+      },
+      "original": {
+        "value": "'ital' 1",
+        "mixin": "textItalic",
+        "property": "font-variation-settings",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        }
+      },
+      "name": "cdr-text-italic-variation",
+      "attributes": {
+        "option": false,
+        "deprecated": false
+      }
+    },
+    {
+      "value": "italic",
+      "mixin": "cdr-textItalic",
+      "property": "font-style",
+      "docs": {
+        "category": "text",
+        "type": "default",
+        "example": "text"
+      },
+      "original": {
+        "value": "italic",
+        "mixin": "textItalic",
+        "property": "font-style",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        }
+      },
+      "name": "cdr-text-italic-style",
+      "attributes": {
+        "option": false,
+        "deprecated": false
+      }
+    },
+    {
+      "value": "700",
+      "mixin": "cdr-textStrong",
+      "property": "font-weight",
+      "docs": {
+        "category": "text",
+        "type": "default",
+        "example": "text"
+      },
+      "original": {
+        "value": "{options.font.weight.strong.value}",
+        "mixin": "textStrong",
+        "property": "font-weight",
+        "docs": {
+          "category": "text",
+          "type": "default",
+          "example": "text"
+        }
+      },
+      "name": "cdr-text-strong-weight",
+      "attributes": {
+        "option": false,
+        "deprecated": false
+      }
     }
   ],
   "sizing": [

--- a/dist/less/cdr-tokens.less
+++ b/dist/less/cdr-tokens.less
@@ -728,6 +728,15 @@
   line-height: 4rem;
 }
 
+.cdr-text-italic() {
+  font-variation-settings: 'ital' 1;
+  font-style: italic;
+}
+
+.cdr-text-strong() {
+  font-weight: 700;
+}
+
 @cdr-color-text-primary: rgba(12, 11, 8, 0.75);
 @cdr-color-text-secondary: rgba(66, 59, 47, 0.75);
 @cdr-color-text-brand: #113731;
@@ -1557,6 +1566,9 @@
 @cdr-text-utility-serif-strong-800-spacing: -0.16px;
 @cdr-text-utility-serif-strong-800-size: 3.2rem;
 @cdr-text-utility-serif-strong-800-height: 4rem;
+@cdr-text-italic-variation: 'ital' 1;
+@cdr-text-italic-style: italic;
+@cdr-text-strong-weight: 700;
 .cdr-display-sr-only {
   position: absolute;
   width: 1px;

--- a/dist/scss/cdr-tokens.scss
+++ b/dist/scss/cdr-tokens.scss
@@ -1350,6 +1350,24 @@
   line-height: 4rem;
 }
 
+@mixin cdr-text-italic() {
+  font-variation-settings: 'ital' 1;
+  font-style: italic;
+}
+
+%cdr-text-italic {
+  font-variation-settings: 'ital' 1;
+  font-style: italic;
+}
+
+@mixin cdr-text-strong() {
+  font-weight: 700;
+}
+
+%cdr-text-strong {
+  font-weight: 700;
+}
+
 $cdr-color-text-primary: rgba(12, 11, 8, 0.75);
 $cdr-color-text-secondary: rgba(66, 59, 47, 0.75);
 $cdr-color-text-brand: #113731;
@@ -2179,6 +2197,9 @@ $cdr-text-utility-serif-strong-800-weight: 600;
 $cdr-text-utility-serif-strong-800-spacing: -0.16px;
 $cdr-text-utility-serif-strong-800-size: 3.2rem;
 $cdr-text-utility-serif-strong-800-height: 4rem;
+$cdr-text-italic-variation: 'ital' 1;
+$cdr-text-italic-style: italic;
+$cdr-text-strong-weight: 700;
 @mixin cdr-display-sr-only() {
   position: absolute;
   width: 1px;
@@ -2322,28 +2343,28 @@ $cdr-text-utility-serif-strong-800-height: 4rem;
 
 // DEPRECATED summer 2020
 @mixin cdr-xs-mq {
-  @include deprecate-mixin('2020', 'summer', 'cdr-xs-mq', 'cdr-xs-mq-up')
+  @include deprecate-mixin('2020', 'summer', 'cdr-xs-mq', 'cdr-xs-mq-up');
   @media (min-width: #{$cdr-breakpoint-xs}) {
     @content;
   }
 }
 
 @mixin cdr-sm-mq {
-  @include deprecate-mixin('2020', 'summer', 'cdr-sm-mq', 'cdr-sm-mq-up')
+  @include deprecate-mixin('2020', 'summer', 'cdr-sm-mq', 'cdr-sm-mq-up');
   @media (min-width: #{$cdr-breakpoint-sm}) {
     @content;
   }
 }
 
 @mixin cdr-md-mq {
-  @include deprecate-mixin('2020', 'summer', 'cdr-md-mq', 'cdr-md-mq-up')
+  @include deprecate-mixin('2020', 'summer', 'cdr-md-mq', 'cdr-md-mq-up');
   @media (min-width: #{$cdr-breakpoint-md}) {
     @content;
   }
 }
 
 @mixin cdr-lg-mq {
-  @include deprecate-mixin('2020', 'summer', 'cdr-lg-mq', 'cdr-lg-mq-up')
+  @include deprecate-mixin('2020', 'summer', 'cdr-lg-mq', 'cdr-lg-mq-up');
   @media (min-width: #{$cdr-breakpoint-lg}) {
     @content;
   }

--- a/dist/sketch/sketch.json
+++ b/dist/sketch/sketch.json
@@ -3910,6 +3910,28 @@
         "800",
         "height"
       ]
+    },
+    {
+      "name": "cdr-text-italic",
+      "value": {
+        "fontVariationSettings": "'ital' 1",
+        "fontStyle": "italic"
+      },
+      "path": [
+        "text-italic",
+        "style"
+      ]
+    },
+    {
+      "name": "cdr-text-strong",
+      "value": {
+        "fontWeightOriginal": 700,
+        "fontWeight": 9
+      },
+      "path": [
+        "text-strong",
+        "weight"
+      ]
     }
   ],
   "prominence": [

--- a/docs/src/assets/cdr-tokens.json
+++ b/docs/src/assets/cdr-tokens.json
@@ -8075,7 +8075,7 @@
       {
         "value": "Mixin content rendered at extra small breakpoint and above",
         "category": "media-query",
-        "name": "cdr-xs-mq",
+        "name": "cdr-xs-mq-up",
         "attributes": {
           "option": false,
           "deprecated": false,
@@ -8095,7 +8095,17 @@
       {
         "value": "Mixin content rendered at small breakpoint and above",
         "category": "media-query",
-        "name": "cdr-sm-mq",
+        "name": "cdr-sm-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered below small breakpoint",
+        "category": "media-query",
+        "name": "cdr-sm-mq-down",
         "attributes": {
           "option": false,
           "deprecated": false,
@@ -8115,7 +8125,17 @@
       {
         "value": "Mixin content rendered at medium breakpoint and above",
         "category": "media-query",
-        "name": "cdr-md-mq",
+        "name": "cdr-md-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered below medium breakpoint",
+        "category": "media-query",
+        "name": "cdr-md-mq-down",
         "attributes": {
           "option": false,
           "deprecated": false,
@@ -8135,7 +8155,17 @@
       {
         "value": "Mixin content rendered at large breakpoint and above",
         "category": "media-query",
-        "name": "cdr-lg-mq",
+        "name": "cdr-lg-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "value": "Mixin content rendered below large breakpoint",
+        "category": "media-query",
+        "name": "cdr-lg-mq-down",
         "attributes": {
           "option": false,
           "deprecated": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "Tokens for REI cedar design system",
   "author": "REI Software Engineering",
   "homepage": "https://rei.github.io/rei-cedar-tokens/#/",

--- a/tokens/_options/font.json5
+++ b/tokens/_options/font.json5
@@ -41,6 +41,7 @@
         normal:   { value: '400' },
         medium:   { value: '500' },
         semibold: { value: '600' },
+        strong:   { value: '700' },
       },
 
       spacing: {

--- a/tokens/web/text-variants.json5
+++ b/tokens/web/text-variants.json5
@@ -1,0 +1,37 @@
+{
+  // default
+  'text-italic': {
+    variation: {
+      value: '\'ital\' 1',
+      mixin: 'textItalic',
+      property: 'font-variation-settings',
+      docs: {
+        category: 'text',
+        type: 'default',
+        example: 'text',
+      },
+    },
+    style: {
+      value: 'italic',
+      mixin: 'textItalic',
+      property: 'font-style',
+      docs: {
+        category: 'text',
+        type: 'default',
+        example: 'text',
+      },
+    },
+  },
+  'text-strong': {
+    weight: {
+      value: '{options.font.weight.strong.value}',
+      mixin: 'textStrong',
+      property: 'font-weight',
+      docs: {
+        category: 'text',
+        type: 'default',
+        example: 'text',
+      },
+    },
+  },
+}


### PR DESCRIPTION
adds mixins for `cdr-text-italic` and `cdr-text-strong`, as we currently had these values hardcoded in cedar. This makes it possible for consumers to use the italic/strong modifiers without relying on the text utility classes.