### PR TITLE
v6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Tokens for REI cedar design system",
   "author": "REI Software Engineering",
   "homepage": "https://rei.github.io/rei-cedar-tokens/#/",

--- a/style-dictionary/utilities/display.less
+++ b/style-dictionary/utilities/display.less
@@ -30,18 +30,18 @@
   padding-right: @cdr-space-one-x;
   width: 100%;
   max-width: @cdr-breakpoint-lg;
-  .cdr-md-mq-up() {
+  .cdr-md-mq-up({
     padding-left: @cdr-space-two-x;
     padding-right: @cdr-space-two-x;
-  }
+  });
 }
 
 .cdr-container-fluid() {
   padding-left: @cdr-space-one-x;
   padding-right: @cdr-space-one-x;
   width: 100%;
-  .cdr-md-mq-up() {
+  .cdr-md-mq-up({
     padding-left: @cdr-space-two-x;
     padding-right: @cdr-space-two-x;
-  }
+  });
 }


### PR DESCRIPTION
- removes deprecated mixin from cdr-container
- adds correct cdr-container mixins to less
