### PR TITLE
fix doc categories for component tokens

### DIFF
--- a/dist/json/android.json
+++ b/dist/json/android.json
@@ -5,7 +5,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for primary buttons"
       },
@@ -14,7 +14,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for primary buttons"
         }
@@ -31,7 +31,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of primary buttons"
       },
@@ -40,7 +40,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of primary buttons"
         }
@@ -57,7 +57,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of primary buttons"
       },
@@ -66,7 +66,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of primary buttons"
         }
@@ -83,7 +83,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled primary buttons"
       },
@@ -92,7 +92,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled primary buttons"
         }
@@ -109,7 +109,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for secondary buttons"
       },
@@ -118,7 +118,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for secondary buttons"
         }
@@ -135,7 +135,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of secondary buttons"
       },
@@ -144,7 +144,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of secondary buttons"
         }
@@ -161,7 +161,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of secondary buttons"
       },
@@ -170,7 +170,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of secondary buttons"
         }
@@ -187,7 +187,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled secondary buttons"
       },
@@ -196,7 +196,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled secondary buttons"
         }
@@ -214,7 +214,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the dark button"
       },
@@ -224,7 +224,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the dark button"
         }
@@ -242,7 +242,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the dark button"
       },
@@ -252,7 +252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the dark button"
         }
@@ -270,7 +270,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the dark button"
       },
@@ -280,7 +280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the dark button"
         }
@@ -298,7 +298,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled dark buttons"
       },
@@ -308,7 +308,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled dark buttons"
         }
@@ -326,7 +326,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the sale button"
       },
@@ -336,7 +336,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the sale button"
         }
@@ -354,7 +354,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the sale button"
       },
@@ -364,7 +364,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the sale button"
         }
@@ -382,7 +382,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the sale button"
       },
@@ -392,7 +392,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the sale button"
         }
@@ -410,7 +410,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled sale buttons"
       },
@@ -420,7 +420,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled sale buttons"
         }
@@ -437,7 +437,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -446,7 +446,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -463,7 +463,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -472,7 +472,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -749,7 +749,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Default text color used in form elements"
       },
@@ -758,7 +758,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Default text color used in form elements"
         }
@@ -775,7 +775,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in form elements"
       },
@@ -784,7 +784,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in form elements"
         }
@@ -801,7 +801,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in disabled form elements"
       },
@@ -810,7 +810,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in disabled form elements"
         }
@@ -827,7 +827,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of placeholder text within forms"
       },
@@ -836,7 +836,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of placeholder text within forms"
         }
@@ -853,7 +853,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of required label within forms"
       },
@@ -862,7 +862,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of required label within forms"
         }
@@ -879,7 +879,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of optional label within forms"
       },
@@ -888,7 +888,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of optional label within forms"
         }
@@ -905,7 +905,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Disabled text color used in form elements"
       },
@@ -914,7 +914,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Disabled text color used in form elements"
         }
@@ -931,7 +931,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color used in filled forms"
       },
@@ -940,7 +940,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color used in filled forms"
         }
@@ -957,7 +957,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Help text color used in forms"
       },
@@ -966,7 +966,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Help text color used in forms"
         }
@@ -983,7 +983,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Error text color used in forms"
       },
@@ -992,7 +992,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Error text color used in forms"
         }
@@ -1009,7 +1009,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for links"
       },
@@ -1018,7 +1018,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for links"
         }
@@ -1035,7 +1035,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the hover state of links"
       },
@@ -1044,7 +1044,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the hover state of links"
         }
@@ -1061,7 +1061,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the active and pressed states of links"
       },
@@ -1070,7 +1070,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the active and pressed states of links"
         }
@@ -1087,7 +1087,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Disabled text color of links"
       },
@@ -1096,7 +1096,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Disabled text color of links"
         }
@@ -1113,7 +1113,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color of visited links"
       },
@@ -1122,7 +1122,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color of visited links"
         }
@@ -1139,7 +1139,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for ratings"
       },
@@ -1148,7 +1148,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for ratings"
         }
@@ -1165,7 +1165,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the hover state of ratings"
       },
@@ -1174,7 +1174,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the hover state of ratings"
         }
@@ -1191,7 +1191,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the separator in ratings"
       },
@@ -1200,7 +1200,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the separator in ratings"
         }
@@ -1217,7 +1217,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for tabs"
       },
@@ -1226,7 +1226,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for tabs"
         }
@@ -1243,7 +1243,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the active and pressed states of tabs"
       },
@@ -1252,7 +1252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the active and pressed states of tabs"
         }
@@ -1269,7 +1269,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the hover state of tabs"
       },
@@ -1278,7 +1278,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the hover state of tabs"
         }
@@ -1295,7 +1295,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Disabled text color of tabs"
       },
@@ -1304,7 +1304,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Disabled text color of tabs"
         }
@@ -1321,7 +1321,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Text color for tooltips"
       },
@@ -1330,7 +1330,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Text color for tooltips"
         }
@@ -1347,7 +1347,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the primary button"
       },
@@ -1356,7 +1356,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the primary button"
         }
@@ -1373,7 +1373,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the primary button"
       },
@@ -1382,7 +1382,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the primary button"
         }
@@ -1399,7 +1399,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the primary button"
       },
@@ -1408,7 +1408,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the primary button"
         }
@@ -1425,7 +1425,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Alternate background color for the hover state of the icon button"
       },
@@ -1434,7 +1434,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Alternate background color for the hover state of the icon button"
         }
@@ -1451,7 +1451,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the secondary button"
       },
@@ -1460,7 +1460,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the secondary button"
         }
@@ -1477,7 +1477,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the secondary button"
       },
@@ -1486,7 +1486,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the secondary button"
         }
@@ -1503,7 +1503,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the secondary button"
       },
@@ -1512,7 +1512,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the secondary button"
         }
@@ -1529,7 +1529,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the disabled state of the secondary button"
       },
@@ -1538,7 +1538,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the disabled state of the secondary button"
         }
@@ -1555,7 +1555,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the dark button"
       },
@@ -1564,7 +1564,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the dark button"
         }
@@ -1581,7 +1581,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the dark button"
       },
@@ -1590,7 +1590,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the dark button"
         }
@@ -1607,7 +1607,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the dark button"
       },
@@ -1616,7 +1616,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the dark button"
         }
@@ -1633,7 +1633,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the sale button"
       },
@@ -1642,7 +1642,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the sale button"
         }
@@ -1659,7 +1659,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the sale button"
       },
@@ -1668,7 +1668,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the sale button"
         }
@@ -1685,7 +1685,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the sale button"
       },
@@ -1694,7 +1694,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the sale button"
         }
@@ -1711,7 +1711,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -1720,7 +1720,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -1737,7 +1737,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the icon only button active and focus states"
       },
@@ -1746,7 +1746,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the icon only button active and focus states"
         }
@@ -1763,7 +1763,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for chips"
       },
@@ -1772,7 +1772,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for chips"
         }
@@ -1789,7 +1789,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for disabled chips"
       },
@@ -1798,7 +1798,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for disabled chips"
         }
@@ -1815,7 +1815,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered chips"
       },
@@ -1824,7 +1824,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered chips"
         }
@@ -1841,7 +1841,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused chips"
       },
@@ -1850,7 +1850,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused chips"
         }
@@ -1867,7 +1867,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for active chips"
       },
@@ -1876,7 +1876,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for active chips"
         }
@@ -1893,7 +1893,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for selected chips"
       },
@@ -1902,7 +1902,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for selected chips"
         }
@@ -1919,7 +1919,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered selected chips"
       },
@@ -1928,7 +1928,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered selected chips"
         }
@@ -1945,7 +1945,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused selected chips"
       },
@@ -1954,7 +1954,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused selected chips"
         }
@@ -2153,7 +2153,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "accordion",
         "example": "color",
         "description": "Background color for the hover state of accordion"
       },
@@ -2162,7 +2162,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "accordion",
           "example": "color",
           "description": "Background color for the hover state of accordion"
         }
@@ -2179,7 +2179,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the hover state of pagination"
       },
@@ -2188,7 +2188,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the hover state of pagination"
         }
@@ -2205,7 +2205,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the pagination keyline"
       },
@@ -2214,7 +2214,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the pagination keyline"
         }
@@ -2231,7 +2231,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "modal",
         "example": "color",
         "description": "The background overlay for modal"
       },
@@ -2240,7 +2240,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "modal",
           "example": "color",
           "description": "The background overlay for modal"
         }
@@ -2257,7 +2257,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background"
       },
@@ -2266,7 +2266,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background"
         }
@@ -2283,7 +2283,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background"
       },
@@ -2292,7 +2292,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background"
         }
@@ -2309,7 +2309,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background"
       },
@@ -2318,7 +2318,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background"
         }
@@ -2335,7 +2335,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background on secondary"
       },
@@ -2344,7 +2344,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background on secondary"
         }
@@ -2361,7 +2361,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background on secondary"
       },
@@ -2370,7 +2370,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background on secondary"
         }
@@ -2387,7 +2387,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background on secondary"
       },
@@ -2396,7 +2396,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background on secondary"
         }
@@ -2413,7 +2413,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2422,7 +2422,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2439,7 +2439,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2448,7 +2448,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2465,7 +2465,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Error background color on form elements"
       },
@@ -2474,7 +2474,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Error background color on form elements"
         }
@@ -2491,7 +2491,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element background"
       },
@@ -2500,7 +2500,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element background"
         }
@@ -2517,7 +2517,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a form element background"
       },
@@ -2526,7 +2526,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a form element background"
         }
@@ -2543,7 +2543,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element background"
       },
@@ -2552,7 +2552,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element background"
         }
@@ -2569,7 +2569,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of an input or select element background on secondary"
       },
@@ -2578,7 +2578,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of an input or select element background on secondary"
         }
@@ -2595,7 +2595,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element background"
       },
@@ -2604,7 +2604,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element background"
         }
@@ -2621,7 +2621,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element background"
       },
@@ -2630,7 +2630,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element background"
         }
@@ -2647,7 +2647,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected focus state of checkbox or radio element background"
       },
@@ -2656,7 +2656,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected focus state of checkbox or radio element background"
         }
@@ -2673,7 +2673,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused checkbox or radio form element background"
       },
@@ -2682,7 +2682,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused checkbox or radio form element background"
         }
@@ -2699,7 +2699,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "The defaul background color of the rating star icon"
       },
@@ -2708,7 +2708,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "The defaul background color of the rating star icon"
         }
@@ -2725,7 +2725,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "Background color for the highlighted rating icon"
       },
@@ -2734,7 +2734,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "Background color for the highlighted rating icon"
         }
@@ -2751,7 +2751,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table headers"
       },
@@ -2760,7 +2760,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table headers"
         }
@@ -2777,7 +2777,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table rows"
       },
@@ -2786,7 +2786,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table rows"
         }
@@ -2803,7 +2803,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "An alternate row color to aid grouping row data"
       },
@@ -2812,7 +2812,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "An alternate row color to aid grouping row data"
         }
@@ -2829,7 +2829,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Background color for tooltips"
       },
@@ -2838,7 +2838,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Background color for tooltips"
         }
@@ -2855,7 +2855,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the primary button"
       },
@@ -2864,7 +2864,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the primary button"
         }
@@ -2881,7 +2881,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the primary button"
       },
@@ -2890,7 +2890,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the primary button"
         }
@@ -2907,7 +2907,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the primary button"
       },
@@ -2916,7 +2916,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the primary button"
         }
@@ -2933,7 +2933,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the primary button"
       },
@@ -2942,7 +2942,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the primary button"
         }
@@ -2959,7 +2959,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the secondary button"
       },
@@ -2968,7 +2968,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the secondary button"
         }
@@ -2985,7 +2985,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the secondary button"
       },
@@ -2994,7 +2994,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the secondary button"
         }
@@ -3011,7 +3011,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the secondary button"
       },
@@ -3020,7 +3020,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the secondary button"
         }
@@ -3037,7 +3037,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the secondary button"
       },
@@ -3046,7 +3046,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the secondary button"
         }
@@ -3063,7 +3063,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the dark button"
       },
@@ -3072,7 +3072,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the dark button"
         }
@@ -3089,7 +3089,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the dark button"
       },
@@ -3098,7 +3098,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the dark button"
         }
@@ -3115,7 +3115,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the dark button"
       },
@@ -3124,7 +3124,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the dark button"
         }
@@ -3141,7 +3141,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the dark button"
       },
@@ -3150,7 +3150,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the dark button"
         }
@@ -3167,7 +3167,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the sale button"
       },
@@ -3176,7 +3176,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the sale button"
         }
@@ -3193,7 +3193,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the sale button"
       },
@@ -3202,7 +3202,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the sale button"
         }
@@ -3219,7 +3219,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the sale button"
       },
@@ -3228,7 +3228,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the sale button"
         }
@@ -3245,7 +3245,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the sale button"
       },
@@ -3254,7 +3254,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the sale button"
         }
@@ -3271,7 +3271,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -3280,7 +3280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -3297,7 +3297,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the icon only button active and focus states"
       },
@@ -3306,7 +3306,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the icon only button active and focus states"
         }
@@ -3323,7 +3323,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for chips"
       },
@@ -3332,7 +3332,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for chips"
         }
@@ -3349,7 +3349,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for disabled chips"
       },
@@ -3358,7 +3358,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for disabled chips"
         }
@@ -3375,7 +3375,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered chips"
       },
@@ -3384,7 +3384,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered chips"
         }
@@ -3401,7 +3401,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused chips"
       },
@@ -3410,7 +3410,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused chips"
         }
@@ -3427,7 +3427,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for active chips"
       },
@@ -3436,7 +3436,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for active chips"
         }
@@ -3453,7 +3453,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for selected chips"
       },
@@ -3462,7 +3462,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for selected chips"
         }
@@ -3479,7 +3479,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered selected chips"
       },
@@ -3488,7 +3488,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered selected chips"
         }
@@ -3505,7 +3505,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused selected chips"
       },
@@ -3514,7 +3514,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused selected chips"
         }
@@ -3687,7 +3687,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focused border color on checkbox or radio labels"
       },
@@ -3696,7 +3696,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focused border color on checkbox or radio labels"
         }
@@ -3713,7 +3713,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Default border color on form elements"
       },
@@ -3722,7 +3722,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Default border color on form elements"
         }
@@ -3739,7 +3739,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Error border color on form elements"
       },
@@ -3748,7 +3748,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Error border color on form elements"
         }
@@ -3765,7 +3765,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover/active/focus state of a checkbox or radio element border"
       },
@@ -3774,7 +3774,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover/active/focus state of a checkbox or radio element border"
         }
@@ -3791,7 +3791,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element border"
       },
@@ -3800,7 +3800,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element border"
         }
@@ -3817,7 +3817,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focus state of an input or select element border"
       },
@@ -3826,7 +3826,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focus state of an input or select element border"
         }
@@ -3843,7 +3843,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element border"
       },
@@ -3852,7 +3852,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element border"
         }
@@ -3869,7 +3869,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element border"
       },
@@ -3878,7 +3878,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element border"
         }
@@ -3895,7 +3895,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element border"
       },
@@ -3904,7 +3904,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element border"
         }
@@ -3921,7 +3921,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for underlined links"
       },
@@ -3930,7 +3930,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for underlined links"
         }
@@ -3947,7 +3947,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the hover state of underlined links"
       },
@@ -3956,7 +3956,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the hover state of underlined links"
         }
@@ -3973,7 +3973,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the active and pressed states of underlined links"
       },
@@ -3982,7 +3982,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the active and pressed states of underlined links"
         }
@@ -3999,7 +3999,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Disabled border color of underlined links"
       },
@@ -4008,7 +4008,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Disabled border color of underlined links"
         }
@@ -4025,7 +4025,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color of visited underlined links"
       },
@@ -4034,7 +4034,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color of visited underlined links"
         }
@@ -4051,7 +4051,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Default border color for the unhighlighted rating icon"
       },
@@ -4060,7 +4060,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Default border color for the unhighlighted rating icon"
         }
@@ -4077,7 +4077,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Border color for the highlighted rating icon"
       },
@@ -4086,7 +4086,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Border color for the highlighted rating icon"
         }
@@ -4103,7 +4103,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "The border color of tab keyline"
       },
@@ -4112,7 +4112,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "The border color of tab keyline"
         }
@@ -4129,7 +4129,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the active tab keyline"
       },
@@ -4138,7 +4138,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the active tab keyline"
         }
@@ -4155,7 +4155,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the active tab keyline"
       },
@@ -4164,7 +4164,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the active tab keyline"
         }
@@ -4181,7 +4181,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the tab keyline hover state"
       },
@@ -4190,7 +4190,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the tab keyline hover state"
         }
@@ -4207,7 +4207,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the tab keyline hover state"
       },
@@ -4216,7 +4216,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the tab keyline hover state"
         }
@@ -4233,7 +4233,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the disabled tab keyline"
       },
@@ -4242,7 +4242,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the disabled tab keyline"
         }
@@ -4259,7 +4259,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "The border color of table rows and their corresponding data cells"
       },
@@ -4268,7 +4268,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "The border color of table rows and their corresponding data cells"
         }
@@ -4285,7 +4285,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "Border color separating complex table heads"
       },
@@ -4294,7 +4294,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "Border color separating complex table heads"
         }
@@ -4311,7 +4311,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Border color for tooltips"
       },
@@ -4320,7 +4320,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Border color for tooltips"
         }
@@ -4441,7 +4441,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Rest state of a selected form icon"
       },
@@ -4450,7 +4450,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Rest state of a selected form icon"
         }
@@ -4467,7 +4467,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4476,7 +4476,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }
@@ -4493,7 +4493,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4502,7 +4502,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }

--- a/dist/json/global.json
+++ b/dist/json/global.json
@@ -5,7 +5,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for primary buttons"
       },
@@ -14,7 +14,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for primary buttons"
         }
@@ -31,7 +31,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of primary buttons"
       },
@@ -40,7 +40,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of primary buttons"
         }
@@ -57,7 +57,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of primary buttons"
       },
@@ -66,7 +66,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of primary buttons"
         }
@@ -83,7 +83,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled primary buttons"
       },
@@ -92,7 +92,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled primary buttons"
         }
@@ -109,7 +109,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for secondary buttons"
       },
@@ -118,7 +118,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for secondary buttons"
         }
@@ -135,7 +135,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of secondary buttons"
       },
@@ -144,7 +144,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of secondary buttons"
         }
@@ -161,7 +161,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of secondary buttons"
       },
@@ -170,7 +170,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of secondary buttons"
         }
@@ -187,7 +187,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled secondary buttons"
       },
@@ -196,7 +196,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled secondary buttons"
         }
@@ -214,7 +214,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the dark button"
       },
@@ -224,7 +224,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the dark button"
         }
@@ -242,7 +242,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the dark button"
       },
@@ -252,7 +252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the dark button"
         }
@@ -270,7 +270,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the dark button"
       },
@@ -280,7 +280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the dark button"
         }
@@ -298,7 +298,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled dark buttons"
       },
@@ -308,7 +308,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled dark buttons"
         }
@@ -326,7 +326,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the sale button"
       },
@@ -336,7 +336,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the sale button"
         }
@@ -354,7 +354,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the sale button"
       },
@@ -364,7 +364,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the sale button"
         }
@@ -382,7 +382,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the sale button"
       },
@@ -392,7 +392,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the sale button"
         }
@@ -410,7 +410,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled sale buttons"
       },
@@ -420,7 +420,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled sale buttons"
         }
@@ -437,7 +437,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -446,7 +446,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -463,7 +463,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -472,7 +472,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -749,7 +749,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Default text color used in form elements"
       },
@@ -758,7 +758,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Default text color used in form elements"
         }
@@ -775,7 +775,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in form elements"
       },
@@ -784,7 +784,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in form elements"
         }
@@ -801,7 +801,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in disabled form elements"
       },
@@ -810,7 +810,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in disabled form elements"
         }
@@ -827,7 +827,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of placeholder text within forms"
       },
@@ -836,7 +836,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of placeholder text within forms"
         }
@@ -853,7 +853,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of required label within forms"
       },
@@ -862,7 +862,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of required label within forms"
         }
@@ -879,7 +879,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of optional label within forms"
       },
@@ -888,7 +888,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of optional label within forms"
         }
@@ -905,7 +905,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Disabled text color used in form elements"
       },
@@ -914,7 +914,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Disabled text color used in form elements"
         }
@@ -931,7 +931,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color used in filled forms"
       },
@@ -940,7 +940,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color used in filled forms"
         }
@@ -957,7 +957,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Help text color used in forms"
       },
@@ -966,7 +966,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Help text color used in forms"
         }
@@ -983,7 +983,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Error text color used in forms"
       },
@@ -992,7 +992,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Error text color used in forms"
         }
@@ -1009,7 +1009,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for links"
       },
@@ -1018,7 +1018,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for links"
         }
@@ -1035,7 +1035,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the hover state of links"
       },
@@ -1044,7 +1044,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the hover state of links"
         }
@@ -1061,7 +1061,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the active and pressed states of links"
       },
@@ -1070,7 +1070,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the active and pressed states of links"
         }
@@ -1087,7 +1087,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Disabled text color of links"
       },
@@ -1096,7 +1096,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Disabled text color of links"
         }
@@ -1113,7 +1113,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color of visited links"
       },
@@ -1122,7 +1122,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color of visited links"
         }
@@ -1139,7 +1139,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for ratings"
       },
@@ -1148,7 +1148,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for ratings"
         }
@@ -1165,7 +1165,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the hover state of ratings"
       },
@@ -1174,7 +1174,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the hover state of ratings"
         }
@@ -1191,7 +1191,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the separator in ratings"
       },
@@ -1200,7 +1200,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the separator in ratings"
         }
@@ -1217,7 +1217,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for tabs"
       },
@@ -1226,7 +1226,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for tabs"
         }
@@ -1243,7 +1243,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the active and pressed states of tabs"
       },
@@ -1252,7 +1252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the active and pressed states of tabs"
         }
@@ -1269,7 +1269,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the hover state of tabs"
       },
@@ -1278,7 +1278,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the hover state of tabs"
         }
@@ -1295,7 +1295,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Disabled text color of tabs"
       },
@@ -1304,7 +1304,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Disabled text color of tabs"
         }
@@ -1321,7 +1321,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Text color for tooltips"
       },
@@ -1330,7 +1330,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Text color for tooltips"
         }
@@ -1347,7 +1347,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the primary button"
       },
@@ -1356,7 +1356,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the primary button"
         }
@@ -1373,7 +1373,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the primary button"
       },
@@ -1382,7 +1382,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the primary button"
         }
@@ -1399,7 +1399,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the primary button"
       },
@@ -1408,7 +1408,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the primary button"
         }
@@ -1425,7 +1425,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Alternate background color for the hover state of the icon button"
       },
@@ -1434,7 +1434,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Alternate background color for the hover state of the icon button"
         }
@@ -1451,7 +1451,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the secondary button"
       },
@@ -1460,7 +1460,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the secondary button"
         }
@@ -1477,7 +1477,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the secondary button"
       },
@@ -1486,7 +1486,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the secondary button"
         }
@@ -1503,7 +1503,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the secondary button"
       },
@@ -1512,7 +1512,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the secondary button"
         }
@@ -1529,7 +1529,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the disabled state of the secondary button"
       },
@@ -1538,7 +1538,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the disabled state of the secondary button"
         }
@@ -1555,7 +1555,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the dark button"
       },
@@ -1564,7 +1564,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the dark button"
         }
@@ -1581,7 +1581,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the dark button"
       },
@@ -1590,7 +1590,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the dark button"
         }
@@ -1607,7 +1607,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the dark button"
       },
@@ -1616,7 +1616,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the dark button"
         }
@@ -1633,7 +1633,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the sale button"
       },
@@ -1642,7 +1642,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the sale button"
         }
@@ -1659,7 +1659,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the sale button"
       },
@@ -1668,7 +1668,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the sale button"
         }
@@ -1685,7 +1685,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the sale button"
       },
@@ -1694,7 +1694,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the sale button"
         }
@@ -1711,7 +1711,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -1720,7 +1720,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -1737,7 +1737,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the icon only button active and focus states"
       },
@@ -1746,7 +1746,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the icon only button active and focus states"
         }
@@ -1763,7 +1763,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for chips"
       },
@@ -1772,7 +1772,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for chips"
         }
@@ -1789,7 +1789,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for disabled chips"
       },
@@ -1798,7 +1798,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for disabled chips"
         }
@@ -1815,7 +1815,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered chips"
       },
@@ -1824,7 +1824,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered chips"
         }
@@ -1841,7 +1841,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused chips"
       },
@@ -1850,7 +1850,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused chips"
         }
@@ -1867,7 +1867,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for active chips"
       },
@@ -1876,7 +1876,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for active chips"
         }
@@ -1893,7 +1893,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for selected chips"
       },
@@ -1902,7 +1902,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for selected chips"
         }
@@ -1919,7 +1919,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered selected chips"
       },
@@ -1928,7 +1928,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered selected chips"
         }
@@ -1945,7 +1945,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused selected chips"
       },
@@ -1954,7 +1954,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused selected chips"
         }
@@ -2153,7 +2153,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "accordion",
         "example": "color",
         "description": "Background color for the hover state of accordion"
       },
@@ -2162,7 +2162,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "accordion",
           "example": "color",
           "description": "Background color for the hover state of accordion"
         }
@@ -2179,7 +2179,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the hover state of pagination"
       },
@@ -2188,7 +2188,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the hover state of pagination"
         }
@@ -2205,7 +2205,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the pagination keyline"
       },
@@ -2214,7 +2214,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the pagination keyline"
         }
@@ -2231,7 +2231,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "modal",
         "example": "color",
         "description": "The background overlay for modal"
       },
@@ -2240,7 +2240,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "modal",
           "example": "color",
           "description": "The background overlay for modal"
         }
@@ -2257,7 +2257,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background"
       },
@@ -2266,7 +2266,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background"
         }
@@ -2283,7 +2283,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background"
       },
@@ -2292,7 +2292,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background"
         }
@@ -2309,7 +2309,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background"
       },
@@ -2318,7 +2318,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background"
         }
@@ -2335,7 +2335,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background on secondary"
       },
@@ -2344,7 +2344,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background on secondary"
         }
@@ -2361,7 +2361,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background on secondary"
       },
@@ -2370,7 +2370,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background on secondary"
         }
@@ -2387,7 +2387,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background on secondary"
       },
@@ -2396,7 +2396,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background on secondary"
         }
@@ -2413,7 +2413,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2422,7 +2422,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2439,7 +2439,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2448,7 +2448,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2465,7 +2465,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Error background color on form elements"
       },
@@ -2474,7 +2474,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Error background color on form elements"
         }
@@ -2491,7 +2491,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element background"
       },
@@ -2500,7 +2500,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element background"
         }
@@ -2517,7 +2517,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a form element background"
       },
@@ -2526,7 +2526,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a form element background"
         }
@@ -2543,7 +2543,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element background"
       },
@@ -2552,7 +2552,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element background"
         }
@@ -2569,7 +2569,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of an input or select element background on secondary"
       },
@@ -2578,7 +2578,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of an input or select element background on secondary"
         }
@@ -2595,7 +2595,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element background"
       },
@@ -2604,7 +2604,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element background"
         }
@@ -2621,7 +2621,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element background"
       },
@@ -2630,7 +2630,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element background"
         }
@@ -2647,7 +2647,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected focus state of checkbox or radio element background"
       },
@@ -2656,7 +2656,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected focus state of checkbox or radio element background"
         }
@@ -2673,7 +2673,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused checkbox or radio form element background"
       },
@@ -2682,7 +2682,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused checkbox or radio form element background"
         }
@@ -2699,7 +2699,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "The defaul background color of the rating star icon"
       },
@@ -2708,7 +2708,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "The defaul background color of the rating star icon"
         }
@@ -2725,7 +2725,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "Background color for the highlighted rating icon"
       },
@@ -2734,7 +2734,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "Background color for the highlighted rating icon"
         }
@@ -2751,7 +2751,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table headers"
       },
@@ -2760,7 +2760,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table headers"
         }
@@ -2777,7 +2777,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table rows"
       },
@@ -2786,7 +2786,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table rows"
         }
@@ -2803,7 +2803,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "An alternate row color to aid grouping row data"
       },
@@ -2812,7 +2812,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "An alternate row color to aid grouping row data"
         }
@@ -2829,7 +2829,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Background color for tooltips"
       },
@@ -2838,7 +2838,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Background color for tooltips"
         }
@@ -2855,7 +2855,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the primary button"
       },
@@ -2864,7 +2864,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the primary button"
         }
@@ -2881,7 +2881,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the primary button"
       },
@@ -2890,7 +2890,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the primary button"
         }
@@ -2907,7 +2907,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the primary button"
       },
@@ -2916,7 +2916,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the primary button"
         }
@@ -2933,7 +2933,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the primary button"
       },
@@ -2942,7 +2942,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the primary button"
         }
@@ -2959,7 +2959,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the secondary button"
       },
@@ -2968,7 +2968,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the secondary button"
         }
@@ -2985,7 +2985,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the secondary button"
       },
@@ -2994,7 +2994,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the secondary button"
         }
@@ -3011,7 +3011,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the secondary button"
       },
@@ -3020,7 +3020,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the secondary button"
         }
@@ -3037,7 +3037,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the secondary button"
       },
@@ -3046,7 +3046,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the secondary button"
         }
@@ -3063,7 +3063,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the dark button"
       },
@@ -3072,7 +3072,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the dark button"
         }
@@ -3089,7 +3089,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the dark button"
       },
@@ -3098,7 +3098,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the dark button"
         }
@@ -3115,7 +3115,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the dark button"
       },
@@ -3124,7 +3124,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the dark button"
         }
@@ -3141,7 +3141,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the dark button"
       },
@@ -3150,7 +3150,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the dark button"
         }
@@ -3167,7 +3167,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the sale button"
       },
@@ -3176,7 +3176,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the sale button"
         }
@@ -3193,7 +3193,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the sale button"
       },
@@ -3202,7 +3202,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the sale button"
         }
@@ -3219,7 +3219,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the sale button"
       },
@@ -3228,7 +3228,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the sale button"
         }
@@ -3245,7 +3245,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the sale button"
       },
@@ -3254,7 +3254,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the sale button"
         }
@@ -3271,7 +3271,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -3280,7 +3280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -3297,7 +3297,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the icon only button active and focus states"
       },
@@ -3306,7 +3306,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the icon only button active and focus states"
         }
@@ -3323,7 +3323,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for chips"
       },
@@ -3332,7 +3332,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for chips"
         }
@@ -3349,7 +3349,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for disabled chips"
       },
@@ -3358,7 +3358,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for disabled chips"
         }
@@ -3375,7 +3375,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered chips"
       },
@@ -3384,7 +3384,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered chips"
         }
@@ -3401,7 +3401,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused chips"
       },
@@ -3410,7 +3410,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused chips"
         }
@@ -3427,7 +3427,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for active chips"
       },
@@ -3436,7 +3436,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for active chips"
         }
@@ -3453,7 +3453,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for selected chips"
       },
@@ -3462,7 +3462,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for selected chips"
         }
@@ -3479,7 +3479,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered selected chips"
       },
@@ -3488,7 +3488,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered selected chips"
         }
@@ -3505,7 +3505,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused selected chips"
       },
@@ -3514,7 +3514,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused selected chips"
         }
@@ -3687,7 +3687,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focused border color on checkbox or radio labels"
       },
@@ -3696,7 +3696,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focused border color on checkbox or radio labels"
         }
@@ -3713,7 +3713,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Default border color on form elements"
       },
@@ -3722,7 +3722,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Default border color on form elements"
         }
@@ -3739,7 +3739,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Error border color on form elements"
       },
@@ -3748,7 +3748,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Error border color on form elements"
         }
@@ -3765,7 +3765,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover/active/focus state of a checkbox or radio element border"
       },
@@ -3774,7 +3774,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover/active/focus state of a checkbox or radio element border"
         }
@@ -3791,7 +3791,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element border"
       },
@@ -3800,7 +3800,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element border"
         }
@@ -3817,7 +3817,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focus state of an input or select element border"
       },
@@ -3826,7 +3826,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focus state of an input or select element border"
         }
@@ -3843,7 +3843,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element border"
       },
@@ -3852,7 +3852,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element border"
         }
@@ -3869,7 +3869,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element border"
       },
@@ -3878,7 +3878,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element border"
         }
@@ -3895,7 +3895,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element border"
       },
@@ -3904,7 +3904,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element border"
         }
@@ -3921,7 +3921,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for underlined links"
       },
@@ -3930,7 +3930,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for underlined links"
         }
@@ -3947,7 +3947,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the hover state of underlined links"
       },
@@ -3956,7 +3956,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the hover state of underlined links"
         }
@@ -3973,7 +3973,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the active and pressed states of underlined links"
       },
@@ -3982,7 +3982,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the active and pressed states of underlined links"
         }
@@ -3999,7 +3999,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Disabled border color of underlined links"
       },
@@ -4008,7 +4008,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Disabled border color of underlined links"
         }
@@ -4025,7 +4025,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color of visited underlined links"
       },
@@ -4034,7 +4034,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color of visited underlined links"
         }
@@ -4051,7 +4051,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Default border color for the unhighlighted rating icon"
       },
@@ -4060,7 +4060,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Default border color for the unhighlighted rating icon"
         }
@@ -4077,7 +4077,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Border color for the highlighted rating icon"
       },
@@ -4086,7 +4086,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Border color for the highlighted rating icon"
         }
@@ -4103,7 +4103,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "The border color of tab keyline"
       },
@@ -4112,7 +4112,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "The border color of tab keyline"
         }
@@ -4129,7 +4129,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the active tab keyline"
       },
@@ -4138,7 +4138,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the active tab keyline"
         }
@@ -4155,7 +4155,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the active tab keyline"
       },
@@ -4164,7 +4164,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the active tab keyline"
         }
@@ -4181,7 +4181,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the tab keyline hover state"
       },
@@ -4190,7 +4190,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the tab keyline hover state"
         }
@@ -4207,7 +4207,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the tab keyline hover state"
       },
@@ -4216,7 +4216,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the tab keyline hover state"
         }
@@ -4233,7 +4233,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the disabled tab keyline"
       },
@@ -4242,7 +4242,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the disabled tab keyline"
         }
@@ -4259,7 +4259,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "The border color of table rows and their corresponding data cells"
       },
@@ -4268,7 +4268,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "The border color of table rows and their corresponding data cells"
         }
@@ -4285,7 +4285,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "Border color separating complex table heads"
       },
@@ -4294,7 +4294,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "Border color separating complex table heads"
         }
@@ -4311,7 +4311,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Border color for tooltips"
       },
@@ -4320,7 +4320,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Border color for tooltips"
         }
@@ -4441,7 +4441,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Rest state of a selected form icon"
       },
@@ -4450,7 +4450,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Rest state of a selected form icon"
         }
@@ -4467,7 +4467,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4476,7 +4476,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }
@@ -4493,7 +4493,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4502,7 +4502,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }

--- a/dist/json/ios.json
+++ b/dist/json/ios.json
@@ -5,7 +5,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for primary buttons"
       },
@@ -14,7 +14,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for primary buttons"
         }
@@ -31,7 +31,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of primary buttons"
       },
@@ -40,7 +40,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of primary buttons"
         }
@@ -57,7 +57,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of primary buttons"
       },
@@ -66,7 +66,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of primary buttons"
         }
@@ -83,7 +83,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled primary buttons"
       },
@@ -92,7 +92,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled primary buttons"
         }
@@ -109,7 +109,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for secondary buttons"
       },
@@ -118,7 +118,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for secondary buttons"
         }
@@ -135,7 +135,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of secondary buttons"
       },
@@ -144,7 +144,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of secondary buttons"
         }
@@ -161,7 +161,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of secondary buttons"
       },
@@ -170,7 +170,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of secondary buttons"
         }
@@ -187,7 +187,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled secondary buttons"
       },
@@ -196,7 +196,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled secondary buttons"
         }
@@ -214,7 +214,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the dark button"
       },
@@ -224,7 +224,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the dark button"
         }
@@ -242,7 +242,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the dark button"
       },
@@ -252,7 +252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the dark button"
         }
@@ -270,7 +270,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the dark button"
       },
@@ -280,7 +280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the dark button"
         }
@@ -298,7 +298,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled dark buttons"
       },
@@ -308,7 +308,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled dark buttons"
         }
@@ -326,7 +326,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the sale button"
       },
@@ -336,7 +336,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the sale button"
         }
@@ -354,7 +354,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the sale button"
       },
@@ -364,7 +364,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the sale button"
         }
@@ -382,7 +382,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the sale button"
       },
@@ -392,7 +392,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the sale button"
         }
@@ -410,7 +410,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled sale buttons"
       },
@@ -420,7 +420,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled sale buttons"
         }
@@ -437,7 +437,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -446,7 +446,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -463,7 +463,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -472,7 +472,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -749,7 +749,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Default text color used in form elements"
       },
@@ -758,7 +758,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Default text color used in form elements"
         }
@@ -775,7 +775,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in form elements"
       },
@@ -784,7 +784,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in form elements"
         }
@@ -801,7 +801,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in disabled form elements"
       },
@@ -810,7 +810,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in disabled form elements"
         }
@@ -827,7 +827,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of placeholder text within forms"
       },
@@ -836,7 +836,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of placeholder text within forms"
         }
@@ -853,7 +853,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of required label within forms"
       },
@@ -862,7 +862,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of required label within forms"
         }
@@ -879,7 +879,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of optional label within forms"
       },
@@ -888,7 +888,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of optional label within forms"
         }
@@ -905,7 +905,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Disabled text color used in form elements"
       },
@@ -914,7 +914,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Disabled text color used in form elements"
         }
@@ -931,7 +931,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color used in filled forms"
       },
@@ -940,7 +940,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color used in filled forms"
         }
@@ -957,7 +957,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Help text color used in forms"
       },
@@ -966,7 +966,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Help text color used in forms"
         }
@@ -983,7 +983,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Error text color used in forms"
       },
@@ -992,7 +992,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Error text color used in forms"
         }
@@ -1009,7 +1009,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for links"
       },
@@ -1018,7 +1018,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for links"
         }
@@ -1035,7 +1035,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the hover state of links"
       },
@@ -1044,7 +1044,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the hover state of links"
         }
@@ -1061,7 +1061,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the active and pressed states of links"
       },
@@ -1070,7 +1070,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the active and pressed states of links"
         }
@@ -1087,7 +1087,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Disabled text color of links"
       },
@@ -1096,7 +1096,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Disabled text color of links"
         }
@@ -1113,7 +1113,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color of visited links"
       },
@@ -1122,7 +1122,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color of visited links"
         }
@@ -1139,7 +1139,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for ratings"
       },
@@ -1148,7 +1148,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for ratings"
         }
@@ -1165,7 +1165,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the hover state of ratings"
       },
@@ -1174,7 +1174,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the hover state of ratings"
         }
@@ -1191,7 +1191,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the separator in ratings"
       },
@@ -1200,7 +1200,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the separator in ratings"
         }
@@ -1217,7 +1217,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for tabs"
       },
@@ -1226,7 +1226,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for tabs"
         }
@@ -1243,7 +1243,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the active and pressed states of tabs"
       },
@@ -1252,7 +1252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the active and pressed states of tabs"
         }
@@ -1269,7 +1269,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the hover state of tabs"
       },
@@ -1278,7 +1278,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the hover state of tabs"
         }
@@ -1295,7 +1295,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Disabled text color of tabs"
       },
@@ -1304,7 +1304,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Disabled text color of tabs"
         }
@@ -1321,7 +1321,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Text color for tooltips"
       },
@@ -1330,7 +1330,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Text color for tooltips"
         }
@@ -1347,7 +1347,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the primary button"
       },
@@ -1356,7 +1356,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the primary button"
         }
@@ -1373,7 +1373,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the primary button"
       },
@@ -1382,7 +1382,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the primary button"
         }
@@ -1399,7 +1399,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the primary button"
       },
@@ -1408,7 +1408,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the primary button"
         }
@@ -1425,7 +1425,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Alternate background color for the hover state of the icon button"
       },
@@ -1434,7 +1434,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Alternate background color for the hover state of the icon button"
         }
@@ -1451,7 +1451,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the secondary button"
       },
@@ -1460,7 +1460,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the secondary button"
         }
@@ -1477,7 +1477,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the secondary button"
       },
@@ -1486,7 +1486,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the secondary button"
         }
@@ -1503,7 +1503,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the secondary button"
       },
@@ -1512,7 +1512,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the secondary button"
         }
@@ -1529,7 +1529,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the disabled state of the secondary button"
       },
@@ -1538,7 +1538,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the disabled state of the secondary button"
         }
@@ -1555,7 +1555,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the dark button"
       },
@@ -1564,7 +1564,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the dark button"
         }
@@ -1581,7 +1581,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the dark button"
       },
@@ -1590,7 +1590,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the dark button"
         }
@@ -1607,7 +1607,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the dark button"
       },
@@ -1616,7 +1616,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the dark button"
         }
@@ -1633,7 +1633,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the sale button"
       },
@@ -1642,7 +1642,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the sale button"
         }
@@ -1659,7 +1659,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the sale button"
       },
@@ -1668,7 +1668,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the sale button"
         }
@@ -1685,7 +1685,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the sale button"
       },
@@ -1694,7 +1694,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the sale button"
         }
@@ -1711,7 +1711,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -1720,7 +1720,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -1737,7 +1737,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the icon only button active and focus states"
       },
@@ -1746,7 +1746,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the icon only button active and focus states"
         }
@@ -1763,7 +1763,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for chips"
       },
@@ -1772,7 +1772,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for chips"
         }
@@ -1789,7 +1789,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for disabled chips"
       },
@@ -1798,7 +1798,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for disabled chips"
         }
@@ -1815,7 +1815,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered chips"
       },
@@ -1824,7 +1824,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered chips"
         }
@@ -1841,7 +1841,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused chips"
       },
@@ -1850,7 +1850,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused chips"
         }
@@ -1867,7 +1867,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for active chips"
       },
@@ -1876,7 +1876,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for active chips"
         }
@@ -1893,7 +1893,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for selected chips"
       },
@@ -1902,7 +1902,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for selected chips"
         }
@@ -1919,7 +1919,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered selected chips"
       },
@@ -1928,7 +1928,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered selected chips"
         }
@@ -1945,7 +1945,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused selected chips"
       },
@@ -1954,7 +1954,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused selected chips"
         }
@@ -2153,7 +2153,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "accordion",
         "example": "color",
         "description": "Background color for the hover state of accordion"
       },
@@ -2162,7 +2162,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "accordion",
           "example": "color",
           "description": "Background color for the hover state of accordion"
         }
@@ -2179,7 +2179,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the hover state of pagination"
       },
@@ -2188,7 +2188,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the hover state of pagination"
         }
@@ -2205,7 +2205,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the pagination keyline"
       },
@@ -2214,7 +2214,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the pagination keyline"
         }
@@ -2231,7 +2231,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "modal",
         "example": "color",
         "description": "The background overlay for modal"
       },
@@ -2240,7 +2240,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "modal",
           "example": "color",
           "description": "The background overlay for modal"
         }
@@ -2257,7 +2257,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background"
       },
@@ -2266,7 +2266,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background"
         }
@@ -2283,7 +2283,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background"
       },
@@ -2292,7 +2292,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background"
         }
@@ -2309,7 +2309,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background"
       },
@@ -2318,7 +2318,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background"
         }
@@ -2335,7 +2335,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background on secondary"
       },
@@ -2344,7 +2344,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background on secondary"
         }
@@ -2361,7 +2361,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background on secondary"
       },
@@ -2370,7 +2370,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background on secondary"
         }
@@ -2387,7 +2387,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background on secondary"
       },
@@ -2396,7 +2396,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background on secondary"
         }
@@ -2413,7 +2413,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2422,7 +2422,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2439,7 +2439,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2448,7 +2448,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2465,7 +2465,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Error background color on form elements"
       },
@@ -2474,7 +2474,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Error background color on form elements"
         }
@@ -2491,7 +2491,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element background"
       },
@@ -2500,7 +2500,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element background"
         }
@@ -2517,7 +2517,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a form element background"
       },
@@ -2526,7 +2526,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a form element background"
         }
@@ -2543,7 +2543,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element background"
       },
@@ -2552,7 +2552,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element background"
         }
@@ -2569,7 +2569,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of an input or select element background on secondary"
       },
@@ -2578,7 +2578,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of an input or select element background on secondary"
         }
@@ -2595,7 +2595,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element background"
       },
@@ -2604,7 +2604,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element background"
         }
@@ -2621,7 +2621,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element background"
       },
@@ -2630,7 +2630,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element background"
         }
@@ -2647,7 +2647,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected focus state of checkbox or radio element background"
       },
@@ -2656,7 +2656,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected focus state of checkbox or radio element background"
         }
@@ -2673,7 +2673,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused checkbox or radio form element background"
       },
@@ -2682,7 +2682,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused checkbox or radio form element background"
         }
@@ -2699,7 +2699,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "The defaul background color of the rating star icon"
       },
@@ -2708,7 +2708,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "The defaul background color of the rating star icon"
         }
@@ -2725,7 +2725,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "Background color for the highlighted rating icon"
       },
@@ -2734,7 +2734,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "Background color for the highlighted rating icon"
         }
@@ -2751,7 +2751,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table headers"
       },
@@ -2760,7 +2760,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table headers"
         }
@@ -2777,7 +2777,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table rows"
       },
@@ -2786,7 +2786,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table rows"
         }
@@ -2803,7 +2803,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "An alternate row color to aid grouping row data"
       },
@@ -2812,7 +2812,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "An alternate row color to aid grouping row data"
         }
@@ -2829,7 +2829,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Background color for tooltips"
       },
@@ -2838,7 +2838,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Background color for tooltips"
         }
@@ -2855,7 +2855,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the primary button"
       },
@@ -2864,7 +2864,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the primary button"
         }
@@ -2881,7 +2881,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the primary button"
       },
@@ -2890,7 +2890,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the primary button"
         }
@@ -2907,7 +2907,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the primary button"
       },
@@ -2916,7 +2916,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the primary button"
         }
@@ -2933,7 +2933,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the primary button"
       },
@@ -2942,7 +2942,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the primary button"
         }
@@ -2959,7 +2959,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the secondary button"
       },
@@ -2968,7 +2968,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the secondary button"
         }
@@ -2985,7 +2985,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the secondary button"
       },
@@ -2994,7 +2994,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the secondary button"
         }
@@ -3011,7 +3011,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the secondary button"
       },
@@ -3020,7 +3020,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the secondary button"
         }
@@ -3037,7 +3037,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the secondary button"
       },
@@ -3046,7 +3046,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the secondary button"
         }
@@ -3063,7 +3063,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the dark button"
       },
@@ -3072,7 +3072,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the dark button"
         }
@@ -3089,7 +3089,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the dark button"
       },
@@ -3098,7 +3098,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the dark button"
         }
@@ -3115,7 +3115,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the dark button"
       },
@@ -3124,7 +3124,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the dark button"
         }
@@ -3141,7 +3141,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the dark button"
       },
@@ -3150,7 +3150,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the dark button"
         }
@@ -3167,7 +3167,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the sale button"
       },
@@ -3176,7 +3176,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the sale button"
         }
@@ -3193,7 +3193,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the sale button"
       },
@@ -3202,7 +3202,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the sale button"
         }
@@ -3219,7 +3219,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the sale button"
       },
@@ -3228,7 +3228,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the sale button"
         }
@@ -3245,7 +3245,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the sale button"
       },
@@ -3254,7 +3254,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the sale button"
         }
@@ -3271,7 +3271,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -3280,7 +3280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -3297,7 +3297,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the icon only button active and focus states"
       },
@@ -3306,7 +3306,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the icon only button active and focus states"
         }
@@ -3323,7 +3323,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for chips"
       },
@@ -3332,7 +3332,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for chips"
         }
@@ -3349,7 +3349,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for disabled chips"
       },
@@ -3358,7 +3358,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for disabled chips"
         }
@@ -3375,7 +3375,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered chips"
       },
@@ -3384,7 +3384,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered chips"
         }
@@ -3401,7 +3401,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused chips"
       },
@@ -3410,7 +3410,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused chips"
         }
@@ -3427,7 +3427,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for active chips"
       },
@@ -3436,7 +3436,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for active chips"
         }
@@ -3453,7 +3453,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for selected chips"
       },
@@ -3462,7 +3462,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for selected chips"
         }
@@ -3479,7 +3479,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered selected chips"
       },
@@ -3488,7 +3488,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered selected chips"
         }
@@ -3505,7 +3505,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused selected chips"
       },
@@ -3514,7 +3514,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused selected chips"
         }
@@ -3687,7 +3687,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focused border color on checkbox or radio labels"
       },
@@ -3696,7 +3696,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focused border color on checkbox or radio labels"
         }
@@ -3713,7 +3713,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Default border color on form elements"
       },
@@ -3722,7 +3722,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Default border color on form elements"
         }
@@ -3739,7 +3739,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Error border color on form elements"
       },
@@ -3748,7 +3748,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Error border color on form elements"
         }
@@ -3765,7 +3765,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover/active/focus state of a checkbox or radio element border"
       },
@@ -3774,7 +3774,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover/active/focus state of a checkbox or radio element border"
         }
@@ -3791,7 +3791,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element border"
       },
@@ -3800,7 +3800,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element border"
         }
@@ -3817,7 +3817,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focus state of an input or select element border"
       },
@@ -3826,7 +3826,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focus state of an input or select element border"
         }
@@ -3843,7 +3843,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element border"
       },
@@ -3852,7 +3852,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element border"
         }
@@ -3869,7 +3869,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element border"
       },
@@ -3878,7 +3878,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element border"
         }
@@ -3895,7 +3895,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element border"
       },
@@ -3904,7 +3904,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element border"
         }
@@ -3921,7 +3921,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for underlined links"
       },
@@ -3930,7 +3930,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for underlined links"
         }
@@ -3947,7 +3947,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the hover state of underlined links"
       },
@@ -3956,7 +3956,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the hover state of underlined links"
         }
@@ -3973,7 +3973,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the active and pressed states of underlined links"
       },
@@ -3982,7 +3982,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the active and pressed states of underlined links"
         }
@@ -3999,7 +3999,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Disabled border color of underlined links"
       },
@@ -4008,7 +4008,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Disabled border color of underlined links"
         }
@@ -4025,7 +4025,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color of visited underlined links"
       },
@@ -4034,7 +4034,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color of visited underlined links"
         }
@@ -4051,7 +4051,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Default border color for the unhighlighted rating icon"
       },
@@ -4060,7 +4060,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Default border color for the unhighlighted rating icon"
         }
@@ -4077,7 +4077,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Border color for the highlighted rating icon"
       },
@@ -4086,7 +4086,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Border color for the highlighted rating icon"
         }
@@ -4103,7 +4103,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "The border color of tab keyline"
       },
@@ -4112,7 +4112,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "The border color of tab keyline"
         }
@@ -4129,7 +4129,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the active tab keyline"
       },
@@ -4138,7 +4138,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the active tab keyline"
         }
@@ -4155,7 +4155,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the active tab keyline"
       },
@@ -4164,7 +4164,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the active tab keyline"
         }
@@ -4181,7 +4181,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the tab keyline hover state"
       },
@@ -4190,7 +4190,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the tab keyline hover state"
         }
@@ -4207,7 +4207,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the tab keyline hover state"
       },
@@ -4216,7 +4216,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the tab keyline hover state"
         }
@@ -4233,7 +4233,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the disabled tab keyline"
       },
@@ -4242,7 +4242,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the disabled tab keyline"
         }
@@ -4259,7 +4259,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "The border color of table rows and their corresponding data cells"
       },
@@ -4268,7 +4268,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "The border color of table rows and their corresponding data cells"
         }
@@ -4285,7 +4285,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "Border color separating complex table heads"
       },
@@ -4294,7 +4294,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "Border color separating complex table heads"
         }
@@ -4311,7 +4311,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Border color for tooltips"
       },
@@ -4320,7 +4320,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Border color for tooltips"
         }
@@ -4441,7 +4441,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Rest state of a selected form icon"
       },
@@ -4450,7 +4450,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Rest state of a selected form icon"
         }
@@ -4467,7 +4467,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4476,7 +4476,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }
@@ -4493,7 +4493,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4502,7 +4502,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }

--- a/dist/json/platform-tokens.json
+++ b/dist/json/platform-tokens.json
@@ -6,7 +6,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for primary buttons"
         },
@@ -15,7 +15,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for primary buttons"
           }
@@ -32,7 +32,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of primary buttons"
         },
@@ -41,7 +41,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the hover state of primary buttons"
           }
@@ -58,7 +58,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of primary buttons"
         },
@@ -67,7 +67,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the active state of primary buttons"
           }
@@ -84,7 +84,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled primary buttons"
         },
@@ -93,7 +93,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for disabled primary buttons"
           }
@@ -110,7 +110,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for secondary buttons"
         },
@@ -119,7 +119,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for secondary buttons"
           }
@@ -136,7 +136,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of secondary buttons"
         },
@@ -145,7 +145,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the hover state of secondary buttons"
           }
@@ -162,7 +162,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of secondary buttons"
         },
@@ -171,7 +171,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the active state of secondary buttons"
           }
@@ -188,7 +188,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled secondary buttons"
         },
@@ -197,7 +197,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for disabled secondary buttons"
           }
@@ -215,7 +215,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the dark button"
         },
@@ -225,7 +225,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the dark button"
           }
@@ -243,7 +243,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the dark button"
         },
@@ -253,7 +253,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the hover state of the dark button"
           }
@@ -271,7 +271,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the dark button"
         },
@@ -281,7 +281,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the active state of the dark button"
           }
@@ -299,7 +299,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled dark buttons"
         },
@@ -309,7 +309,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for disabled dark buttons"
           }
@@ -327,7 +327,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the sale button"
         },
@@ -337,7 +337,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the sale button"
           }
@@ -355,7 +355,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the sale button"
         },
@@ -365,7 +365,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the hover state of the sale button"
           }
@@ -383,7 +383,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the sale button"
         },
@@ -393,7 +393,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for the active state of the sale button"
           }
@@ -411,7 +411,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled sale buttons"
         },
@@ -421,7 +421,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "button",
             "example": "color",
             "description": "Text color for disabled sale buttons"
           }
@@ -438,7 +438,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         },
@@ -447,7 +447,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Text color for default chips"
           }
@@ -464,7 +464,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         },
@@ -473,7 +473,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Text color for default chips"
           }
@@ -750,7 +750,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Default text color used in form elements"
         },
@@ -759,7 +759,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Default text color used in form elements"
           }
@@ -776,7 +776,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in form elements"
         },
@@ -785,7 +785,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Color of label text used in form elements"
           }
@@ -802,7 +802,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in disabled form elements"
         },
@@ -811,7 +811,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Color of label text used in disabled form elements"
           }
@@ -828,7 +828,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of placeholder text within forms"
         },
@@ -837,7 +837,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Text color of placeholder text within forms"
           }
@@ -854,7 +854,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of required label within forms"
         },
@@ -863,7 +863,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Text color of required label within forms"
           }
@@ -880,7 +880,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of optional label within forms"
         },
@@ -889,7 +889,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Text color of optional label within forms"
           }
@@ -906,7 +906,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Disabled text color used in form elements"
         },
@@ -915,7 +915,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Disabled text color used in form elements"
           }
@@ -932,7 +932,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color used in filled forms"
         },
@@ -941,7 +941,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Text color used in filled forms"
           }
@@ -958,7 +958,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Help text color used in forms"
         },
@@ -967,7 +967,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Help text color used in forms"
           }
@@ -984,7 +984,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Error text color used in forms"
         },
@@ -993,7 +993,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "input",
             "example": "color",
             "description": "Error text color used in forms"
           }
@@ -1010,7 +1010,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for links"
         },
@@ -1019,7 +1019,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "link",
             "example": "color",
             "description": "Text color for links"
           }
@@ -1036,7 +1036,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the hover state of links"
         },
@@ -1045,7 +1045,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "link",
             "example": "color",
             "description": "Text color for the hover state of links"
           }
@@ -1062,7 +1062,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the active and pressed states of links"
         },
@@ -1071,7 +1071,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "link",
             "example": "color",
             "description": "Text color for the active and pressed states of links"
           }
@@ -1088,7 +1088,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Disabled text color of links"
         },
@@ -1097,7 +1097,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "link",
             "example": "color",
             "description": "Disabled text color of links"
           }
@@ -1114,7 +1114,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color of visited links"
         },
@@ -1123,7 +1123,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "link",
             "example": "color",
             "description": "Text color of visited links"
           }
@@ -1140,7 +1140,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for ratings"
         },
@@ -1149,7 +1149,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "rating",
             "example": "color",
             "description": "Text color for ratings"
           }
@@ -1166,7 +1166,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the hover state of ratings"
         },
@@ -1175,7 +1175,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "rating",
             "example": "color",
             "description": "Text color for the hover state of ratings"
           }
@@ -1192,7 +1192,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the separator in ratings"
         },
@@ -1201,7 +1201,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "rating",
             "example": "color",
             "description": "Text color for the separator in ratings"
           }
@@ -1218,7 +1218,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for tabs"
         },
@@ -1227,7 +1227,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tabs",
             "example": "color",
             "description": "Text color for tabs"
           }
@@ -1244,7 +1244,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the active and pressed states of tabs"
         },
@@ -1253,7 +1253,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tabs",
             "example": "color",
             "description": "Text color for the active and pressed states of tabs"
           }
@@ -1270,7 +1270,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the hover state of tabs"
         },
@@ -1279,7 +1279,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tabs",
             "example": "color",
             "description": "Text color for the hover state of tabs"
           }
@@ -1296,7 +1296,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Disabled text color of tabs"
         },
@@ -1305,7 +1305,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tabs",
             "example": "color",
             "description": "Disabled text color of tabs"
           }
@@ -1322,7 +1322,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Text color for tooltips"
         },
@@ -1331,7 +1331,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tooltip",
             "example": "color",
             "description": "Text color for tooltips"
           }
@@ -1348,7 +1348,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the primary button"
         },
@@ -1357,7 +1357,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the primary button"
           }
@@ -1374,7 +1374,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the primary button"
         },
@@ -1383,7 +1383,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the active and pressed states of the primary button"
           }
@@ -1400,7 +1400,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the primary button"
         },
@@ -1409,7 +1409,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the hover state of the primary button"
           }
@@ -1426,7 +1426,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Alternate background color for the hover state of the icon button"
         },
@@ -1435,7 +1435,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Alternate background color for the hover state of the icon button"
           }
@@ -1452,7 +1452,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the secondary button"
         },
@@ -1461,7 +1461,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the secondary button"
           }
@@ -1478,7 +1478,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the secondary button"
         },
@@ -1487,7 +1487,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the active and pressed states of the secondary button"
           }
@@ -1504,7 +1504,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the secondary button"
         },
@@ -1513,7 +1513,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the hover state of the secondary button"
           }
@@ -1530,7 +1530,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the disabled state of the secondary button"
         },
@@ -1539,7 +1539,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the disabled state of the secondary button"
           }
@@ -1556,7 +1556,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the dark button"
         },
@@ -1565,7 +1565,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the dark button"
           }
@@ -1582,7 +1582,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the dark button"
         },
@@ -1591,7 +1591,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the active and pressed states of the dark button"
           }
@@ -1608,7 +1608,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the dark button"
         },
@@ -1617,7 +1617,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the hover state of the dark button"
           }
@@ -1634,7 +1634,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the sale button"
         },
@@ -1643,7 +1643,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the sale button"
           }
@@ -1660,7 +1660,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the sale button"
         },
@@ -1669,7 +1669,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the active and pressed states of the sale button"
           }
@@ -1686,7 +1686,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the sale button"
         },
@@ -1695,7 +1695,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the hover state of the sale button"
           }
@@ -1712,7 +1712,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         },
@@ -1721,7 +1721,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Default disabled border color"
           }
@@ -1738,7 +1738,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the icon only button active and focus states"
         },
@@ -1747,7 +1747,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "button",
             "example": "color",
             "description": "Background color for the icon only button active and focus states"
           }
@@ -1764,7 +1764,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for chips"
         },
@@ -1773,7 +1773,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for chips"
           }
@@ -1790,7 +1790,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for disabled chips"
         },
@@ -1799,7 +1799,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for disabled chips"
           }
@@ -1816,7 +1816,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered chips"
         },
@@ -1825,7 +1825,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for hovered chips"
           }
@@ -1842,7 +1842,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused chips"
         },
@@ -1851,7 +1851,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for focused chips"
           }
@@ -1868,7 +1868,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for active chips"
         },
@@ -1877,7 +1877,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for active chips"
           }
@@ -1894,7 +1894,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for selected chips"
         },
@@ -1903,7 +1903,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for selected chips"
           }
@@ -1920,7 +1920,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered selected chips"
         },
@@ -1929,7 +1929,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for hovered selected chips"
           }
@@ -1946,7 +1946,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused selected chips"
         },
@@ -1955,7 +1955,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Background color for focused selected chips"
           }
@@ -2154,7 +2154,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "accordion",
           "example": "color",
           "description": "Background color for the hover state of accordion"
         },
@@ -2163,7 +2163,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "accordion",
             "example": "color",
             "description": "Background color for the hover state of accordion"
           }
@@ -2180,7 +2180,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the hover state of pagination"
         },
@@ -2189,7 +2189,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "pagination",
             "example": "color",
             "description": "Background color for the hover state of pagination"
           }
@@ -2206,7 +2206,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the pagination keyline"
         },
@@ -2215,7 +2215,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "pagination",
             "example": "color",
             "description": "Background color for the pagination keyline"
           }
@@ -2232,7 +2232,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "modal",
           "example": "color",
           "description": "The background overlay for modal"
         },
@@ -2241,7 +2241,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "modal",
             "example": "color",
             "description": "The background overlay for modal"
           }
@@ -2258,7 +2258,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background"
         },
@@ -2267,7 +2267,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a checkbox or radio label background"
           }
@@ -2284,7 +2284,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background"
         },
@@ -2293,7 +2293,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Active state of a checkbox or radio label background"
           }
@@ -2310,7 +2310,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background"
         },
@@ -2319,7 +2319,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Focused state of a checkbox or radio label background"
           }
@@ -2336,7 +2336,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background on secondary"
         },
@@ -2345,7 +2345,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a checkbox or radio label background on secondary"
           }
@@ -2362,7 +2362,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background on secondary"
         },
@@ -2371,7 +2371,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Active state of a checkbox or radio label background on secondary"
           }
@@ -2388,7 +2388,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background on secondary"
         },
@@ -2397,7 +2397,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Focused state of a checkbox or radio label background on secondary"
           }
@@ -2414,7 +2414,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         },
@@ -2423,7 +2423,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Default background color on form elements"
           }
@@ -2440,7 +2440,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         },
@@ -2449,7 +2449,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Default background color on form elements"
           }
@@ -2466,7 +2466,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Error background color on form elements"
         },
@@ -2475,7 +2475,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Error background color on form elements"
           }
@@ -2492,7 +2492,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element background"
         },
@@ -2501,7 +2501,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a checkbox or radio element background"
           }
@@ -2518,7 +2518,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a form element background"
         },
@@ -2527,7 +2527,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Active state of a form element background"
           }
@@ -2544,7 +2544,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element background"
         },
@@ -2553,7 +2553,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Selected state of a checkbox or radio element background"
           }
@@ -2570,7 +2570,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of an input or select element background on secondary"
         },
@@ -2579,7 +2579,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Active state of an input or select element background on secondary"
           }
@@ -2596,7 +2596,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element background"
         },
@@ -2605,7 +2605,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a selected checkbox or radio element background"
           }
@@ -2622,7 +2622,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element background"
         },
@@ -2631,7 +2631,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Disabled form element background"
           }
@@ -2648,7 +2648,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected focus state of checkbox or radio element background"
         },
@@ -2657,7 +2657,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Selected focus state of checkbox or radio element background"
           }
@@ -2674,7 +2674,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused checkbox or radio form element background"
         },
@@ -2683,7 +2683,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "input",
             "example": "color",
             "description": "Focused checkbox or radio form element background"
           }
@@ -2700,7 +2700,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "The defaul background color of the rating star icon"
         },
@@ -2709,7 +2709,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "rating",
             "example": "color",
             "description": "The defaul background color of the rating star icon"
           }
@@ -2726,7 +2726,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "Background color for the highlighted rating icon"
         },
@@ -2735,7 +2735,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "rating",
             "example": "color",
             "description": "Background color for the highlighted rating icon"
           }
@@ -2752,7 +2752,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table headers"
         },
@@ -2761,7 +2761,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "table",
             "example": "color",
             "description": "The background color of table headers"
           }
@@ -2778,7 +2778,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table rows"
         },
@@ -2787,7 +2787,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "table",
             "example": "color",
             "description": "The background color of table rows"
           }
@@ -2804,7 +2804,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "An alternate row color to aid grouping row data"
         },
@@ -2813,7 +2813,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "background",
+            "type": "table",
             "example": "color",
             "description": "An alternate row color to aid grouping row data"
           }
@@ -2830,7 +2830,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Background color for tooltips"
         },
@@ -2839,7 +2839,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tooltip",
             "example": "color",
             "description": "Background color for tooltips"
           }
@@ -2856,7 +2856,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the primary button"
         },
@@ -2865,7 +2865,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the primary button"
           }
@@ -2882,7 +2882,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the primary button"
         },
@@ -2891,7 +2891,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the active and pressed states of the primary button"
           }
@@ -2908,7 +2908,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the primary button"
         },
@@ -2917,7 +2917,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Inset border for the active state of the primary button"
           }
@@ -2934,7 +2934,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the primary button"
         },
@@ -2943,7 +2943,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the hover state of the primary button"
           }
@@ -2960,7 +2960,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the secondary button"
         },
@@ -2969,7 +2969,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the secondary button"
           }
@@ -2986,7 +2986,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the secondary button"
         },
@@ -2995,7 +2995,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the active and pressed states of the secondary button"
           }
@@ -3012,7 +3012,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the secondary button"
         },
@@ -3021,7 +3021,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Inset border for the active state of the secondary button"
           }
@@ -3038,7 +3038,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the secondary button"
         },
@@ -3047,7 +3047,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the hover state of the secondary button"
           }
@@ -3064,7 +3064,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the dark button"
         },
@@ -3073,7 +3073,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the dark button"
           }
@@ -3090,7 +3090,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the dark button"
         },
@@ -3099,7 +3099,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the active and pressed states of the dark button"
           }
@@ -3116,7 +3116,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the dark button"
         },
@@ -3125,7 +3125,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Inset border for the active state of the dark button"
           }
@@ -3142,7 +3142,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the dark button"
         },
@@ -3151,7 +3151,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the hover state of the dark button"
           }
@@ -3168,7 +3168,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the sale button"
         },
@@ -3177,7 +3177,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the sale button"
           }
@@ -3194,7 +3194,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the sale button"
         },
@@ -3203,7 +3203,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the active and pressed states of the sale button"
           }
@@ -3220,7 +3220,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the sale button"
         },
@@ -3229,7 +3229,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Inset border for the active state of the sale button"
           }
@@ -3246,7 +3246,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the sale button"
         },
@@ -3255,7 +3255,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the hover state of the sale button"
           }
@@ -3272,7 +3272,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         },
@@ -3281,7 +3281,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Default disabled border color"
           }
@@ -3298,7 +3298,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the icon only button active and focus states"
         },
@@ -3307,7 +3307,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "button",
             "example": "color",
             "description": "Border color for the icon only button active and focus states"
           }
@@ -3324,7 +3324,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for chips"
         },
@@ -3333,7 +3333,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for chips"
           }
@@ -3350,7 +3350,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for disabled chips"
         },
@@ -3359,7 +3359,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for disabled chips"
           }
@@ -3376,7 +3376,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered chips"
         },
@@ -3385,7 +3385,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for hovered chips"
           }
@@ -3402,7 +3402,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused chips"
         },
@@ -3411,7 +3411,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for focused chips"
           }
@@ -3428,7 +3428,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for active chips"
         },
@@ -3437,7 +3437,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for active chips"
           }
@@ -3454,7 +3454,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for selected chips"
         },
@@ -3463,7 +3463,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for selected chips"
           }
@@ -3480,7 +3480,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered selected chips"
         },
@@ -3489,7 +3489,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for hovered selected chips"
           }
@@ -3506,7 +3506,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused selected chips"
         },
@@ -3515,7 +3515,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "chip",
             "example": "color",
             "description": "Border color for focused selected chips"
           }
@@ -3688,7 +3688,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focused border color on checkbox or radio labels"
         },
@@ -3697,7 +3697,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Focused border color on checkbox or radio labels"
           }
@@ -3714,7 +3714,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Default border color on form elements"
         },
@@ -3723,7 +3723,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Default border color on form elements"
           }
@@ -3740,7 +3740,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Error border color on form elements"
         },
@@ -3749,7 +3749,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Error border color on form elements"
           }
@@ -3766,7 +3766,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover/active/focus state of a checkbox or radio element border"
         },
@@ -3775,7 +3775,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Hover/active/focus state of a checkbox or radio element border"
           }
@@ -3792,7 +3792,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element border"
         },
@@ -3801,7 +3801,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Selected state of a checkbox or radio element border"
           }
@@ -3818,7 +3818,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focus state of an input or select element border"
         },
@@ -3827,7 +3827,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Focus state of an input or select element border"
           }
@@ -3844,7 +3844,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element border"
         },
@@ -3853,7 +3853,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a selected checkbox or radio element border"
           }
@@ -3870,7 +3870,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element border"
         },
@@ -3879,7 +3879,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a checkbox or radio element border"
           }
@@ -3896,7 +3896,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element border"
         },
@@ -3905,7 +3905,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "input",
             "example": "color",
             "description": "Disabled form element border"
           }
@@ -3922,7 +3922,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for underlined links"
         },
@@ -3931,7 +3931,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "link",
             "example": "color",
             "description": "Border color for underlined links"
           }
@@ -3948,7 +3948,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the hover state of underlined links"
         },
@@ -3957,7 +3957,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "link",
             "example": "color",
             "description": "Border color for the hover state of underlined links"
           }
@@ -3974,7 +3974,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the active and pressed states of underlined links"
         },
@@ -3983,7 +3983,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "link",
             "example": "color",
             "description": "Border color for the active and pressed states of underlined links"
           }
@@ -4000,7 +4000,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Disabled border color of underlined links"
         },
@@ -4009,7 +4009,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "link",
             "example": "color",
             "description": "Disabled border color of underlined links"
           }
@@ -4026,7 +4026,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color of visited underlined links"
         },
@@ -4035,7 +4035,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "link",
             "example": "color",
             "description": "Border color of visited underlined links"
           }
@@ -4052,7 +4052,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Default border color for the unhighlighted rating icon"
         },
@@ -4061,7 +4061,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "rating",
             "example": "color",
             "description": "Default border color for the unhighlighted rating icon"
           }
@@ -4078,7 +4078,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Border color for the highlighted rating icon"
         },
@@ -4087,7 +4087,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "rating",
             "example": "color",
             "description": "Border color for the highlighted rating icon"
           }
@@ -4104,7 +4104,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "The border color of tab keyline"
         },
@@ -4113,7 +4113,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "The border color of tab keyline"
           }
@@ -4130,7 +4130,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the active tab keyline"
         },
@@ -4139,7 +4139,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "Border color for the active tab keyline"
           }
@@ -4156,7 +4156,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the active tab keyline"
         },
@@ -4165,7 +4165,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "Alternative border color for the active tab keyline"
           }
@@ -4182,7 +4182,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the tab keyline hover state"
         },
@@ -4191,7 +4191,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "Border color for the tab keyline hover state"
           }
@@ -4208,7 +4208,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the tab keyline hover state"
         },
@@ -4217,7 +4217,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "Alternative border color for the tab keyline hover state"
           }
@@ -4234,7 +4234,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the disabled tab keyline"
         },
@@ -4243,7 +4243,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "tabs",
             "example": "color",
             "description": "Border color for the disabled tab keyline"
           }
@@ -4260,7 +4260,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "The border color of table rows and their corresponding data cells"
         },
@@ -4269,7 +4269,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "table",
             "example": "color",
             "description": "The border color of table rows and their corresponding data cells"
           }
@@ -4286,7 +4286,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "Border color separating complex table heads"
         },
@@ -4295,7 +4295,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "border",
+            "type": "table",
             "example": "color",
             "description": "Border color separating complex table heads"
           }
@@ -4312,7 +4312,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Border color for tooltips"
         },
@@ -4321,7 +4321,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "text",
+            "type": "tooltip",
             "example": "color",
             "description": "Border color for tooltips"
           }
@@ -4442,7 +4442,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Rest state of a selected form icon"
         },
@@ -4451,7 +4451,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "icon",
+            "type": "input",
             "example": "color",
             "description": "Rest state of a selected form icon"
           }
@@ -4468,7 +4468,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         },
@@ -4477,7 +4477,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "icon",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a selected form icon"
           }
@@ -4494,7 +4494,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         },
@@ -4503,7 +4503,7 @@
           "category": "color",
           "docs": {
             "category": "colors",
-            "type": "icon",
+            "type": "input",
             "example": "color",
             "description": "Hover state of a selected form icon"
           }

--- a/dist/json/web.json
+++ b/dist/json/web.json
@@ -5,7 +5,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for primary buttons"
       },
@@ -14,7 +14,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for primary buttons"
         }
@@ -31,7 +31,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of primary buttons"
       },
@@ -40,7 +40,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of primary buttons"
         }
@@ -57,7 +57,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of primary buttons"
       },
@@ -66,7 +66,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of primary buttons"
         }
@@ -83,7 +83,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled primary buttons"
       },
@@ -92,7 +92,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled primary buttons"
         }
@@ -109,7 +109,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for secondary buttons"
       },
@@ -118,7 +118,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for secondary buttons"
         }
@@ -135,7 +135,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of secondary buttons"
       },
@@ -144,7 +144,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of secondary buttons"
         }
@@ -161,7 +161,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of secondary buttons"
       },
@@ -170,7 +170,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of secondary buttons"
         }
@@ -187,7 +187,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled secondary buttons"
       },
@@ -196,7 +196,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled secondary buttons"
         }
@@ -214,7 +214,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the dark button"
       },
@@ -224,7 +224,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the dark button"
         }
@@ -242,7 +242,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the dark button"
       },
@@ -252,7 +252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the dark button"
         }
@@ -270,7 +270,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the dark button"
       },
@@ -280,7 +280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the dark button"
         }
@@ -298,7 +298,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled dark buttons"
       },
@@ -308,7 +308,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled dark buttons"
         }
@@ -326,7 +326,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the sale button"
       },
@@ -336,7 +336,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the sale button"
         }
@@ -354,7 +354,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the hover state of the sale button"
       },
@@ -364,7 +364,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the hover state of the sale button"
         }
@@ -382,7 +382,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for the active state of the sale button"
       },
@@ -392,7 +392,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for the active state of the sale button"
         }
@@ -410,7 +410,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "button",
         "example": "color",
         "description": "Text color for disabled sale buttons"
       },
@@ -420,7 +420,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "button",
           "example": "color",
           "description": "Text color for disabled sale buttons"
         }
@@ -437,7 +437,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -446,7 +446,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -463,7 +463,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Text color for default chips"
       },
@@ -472,7 +472,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Text color for default chips"
         }
@@ -749,7 +749,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Default text color used in form elements"
       },
@@ -758,7 +758,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Default text color used in form elements"
         }
@@ -775,7 +775,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in form elements"
       },
@@ -784,7 +784,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in form elements"
         }
@@ -801,7 +801,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Color of label text used in disabled form elements"
       },
@@ -810,7 +810,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Color of label text used in disabled form elements"
         }
@@ -827,7 +827,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of placeholder text within forms"
       },
@@ -836,7 +836,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of placeholder text within forms"
         }
@@ -853,7 +853,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of required label within forms"
       },
@@ -862,7 +862,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of required label within forms"
         }
@@ -879,7 +879,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color of optional label within forms"
       },
@@ -888,7 +888,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color of optional label within forms"
         }
@@ -905,7 +905,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Disabled text color used in form elements"
       },
@@ -914,7 +914,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Disabled text color used in form elements"
         }
@@ -931,7 +931,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Text color used in filled forms"
       },
@@ -940,7 +940,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Text color used in filled forms"
         }
@@ -957,7 +957,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Help text color used in forms"
       },
@@ -966,7 +966,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Help text color used in forms"
         }
@@ -983,7 +983,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "input",
         "example": "color",
         "description": "Error text color used in forms"
       },
@@ -992,7 +992,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "input",
           "example": "color",
           "description": "Error text color used in forms"
         }
@@ -1009,7 +1009,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for links"
       },
@@ -1018,7 +1018,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for links"
         }
@@ -1035,7 +1035,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the hover state of links"
       },
@@ -1044,7 +1044,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the hover state of links"
         }
@@ -1061,7 +1061,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color for the active and pressed states of links"
       },
@@ -1070,7 +1070,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color for the active and pressed states of links"
         }
@@ -1087,7 +1087,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Disabled text color of links"
       },
@@ -1096,7 +1096,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Disabled text color of links"
         }
@@ -1113,7 +1113,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "link",
         "example": "color",
         "description": "Text color of visited links"
       },
@@ -1122,7 +1122,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "link",
           "example": "color",
           "description": "Text color of visited links"
         }
@@ -1139,7 +1139,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for ratings"
       },
@@ -1148,7 +1148,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for ratings"
         }
@@ -1165,7 +1165,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the hover state of ratings"
       },
@@ -1174,7 +1174,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the hover state of ratings"
         }
@@ -1191,7 +1191,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "rating",
         "example": "color",
         "description": "Text color for the separator in ratings"
       },
@@ -1200,7 +1200,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "rating",
           "example": "color",
           "description": "Text color for the separator in ratings"
         }
@@ -1217,7 +1217,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for tabs"
       },
@@ -1226,7 +1226,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for tabs"
         }
@@ -1243,7 +1243,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the active and pressed states of tabs"
       },
@@ -1252,7 +1252,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the active and pressed states of tabs"
         }
@@ -1269,7 +1269,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Text color for the hover state of tabs"
       },
@@ -1278,7 +1278,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Text color for the hover state of tabs"
         }
@@ -1295,7 +1295,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tabs",
         "example": "color",
         "description": "Disabled text color of tabs"
       },
@@ -1304,7 +1304,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tabs",
           "example": "color",
           "description": "Disabled text color of tabs"
         }
@@ -1321,7 +1321,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Text color for tooltips"
       },
@@ -1330,7 +1330,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Text color for tooltips"
         }
@@ -1347,7 +1347,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the primary button"
       },
@@ -1356,7 +1356,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the primary button"
         }
@@ -1373,7 +1373,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the primary button"
       },
@@ -1382,7 +1382,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the primary button"
         }
@@ -1399,7 +1399,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the primary button"
       },
@@ -1408,7 +1408,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the primary button"
         }
@@ -1425,7 +1425,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Alternate background color for the hover state of the icon button"
       },
@@ -1434,7 +1434,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Alternate background color for the hover state of the icon button"
         }
@@ -1451,7 +1451,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the secondary button"
       },
@@ -1460,7 +1460,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the secondary button"
         }
@@ -1477,7 +1477,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the secondary button"
       },
@@ -1486,7 +1486,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the secondary button"
         }
@@ -1503,7 +1503,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the secondary button"
       },
@@ -1512,7 +1512,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the secondary button"
         }
@@ -1529,7 +1529,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the disabled state of the secondary button"
       },
@@ -1538,7 +1538,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the disabled state of the secondary button"
         }
@@ -1555,7 +1555,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the dark button"
       },
@@ -1564,7 +1564,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the dark button"
         }
@@ -1581,7 +1581,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the dark button"
       },
@@ -1590,7 +1590,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the dark button"
         }
@@ -1607,7 +1607,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the dark button"
       },
@@ -1616,7 +1616,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the dark button"
         }
@@ -1633,7 +1633,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the sale button"
       },
@@ -1642,7 +1642,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the sale button"
         }
@@ -1659,7 +1659,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the active and pressed states of the sale button"
       },
@@ -1668,7 +1668,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the active and pressed states of the sale button"
         }
@@ -1685,7 +1685,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the hover state of the sale button"
       },
@@ -1694,7 +1694,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the hover state of the sale button"
         }
@@ -1711,7 +1711,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -1720,7 +1720,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -1737,7 +1737,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "button",
         "example": "color",
         "description": "Background color for the icon only button active and focus states"
       },
@@ -1746,7 +1746,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "button",
           "example": "color",
           "description": "Background color for the icon only button active and focus states"
         }
@@ -1763,7 +1763,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for chips"
       },
@@ -1772,7 +1772,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for chips"
         }
@@ -1789,7 +1789,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for disabled chips"
       },
@@ -1798,7 +1798,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for disabled chips"
         }
@@ -1815,7 +1815,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered chips"
       },
@@ -1824,7 +1824,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered chips"
         }
@@ -1841,7 +1841,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused chips"
       },
@@ -1850,7 +1850,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused chips"
         }
@@ -1867,7 +1867,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for active chips"
       },
@@ -1876,7 +1876,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for active chips"
         }
@@ -1893,7 +1893,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for selected chips"
       },
@@ -1902,7 +1902,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for selected chips"
         }
@@ -1919,7 +1919,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for hovered selected chips"
       },
@@ -1928,7 +1928,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for hovered selected chips"
         }
@@ -1945,7 +1945,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Background color for focused selected chips"
       },
@@ -1954,7 +1954,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Background color for focused selected chips"
         }
@@ -2153,7 +2153,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "accordion",
         "example": "color",
         "description": "Background color for the hover state of accordion"
       },
@@ -2162,7 +2162,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "accordion",
           "example": "color",
           "description": "Background color for the hover state of accordion"
         }
@@ -2179,7 +2179,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the hover state of pagination"
       },
@@ -2188,7 +2188,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the hover state of pagination"
         }
@@ -2205,7 +2205,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "pagination",
         "example": "color",
         "description": "Background color for the pagination keyline"
       },
@@ -2214,7 +2214,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "pagination",
           "example": "color",
           "description": "Background color for the pagination keyline"
         }
@@ -2231,7 +2231,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "modal",
         "example": "color",
         "description": "The background overlay for modal"
       },
@@ -2240,7 +2240,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "modal",
           "example": "color",
           "description": "The background overlay for modal"
         }
@@ -2257,7 +2257,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background"
       },
@@ -2266,7 +2266,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background"
         }
@@ -2283,7 +2283,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background"
       },
@@ -2292,7 +2292,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background"
         }
@@ -2309,7 +2309,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background"
       },
@@ -2318,7 +2318,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background"
         }
@@ -2335,7 +2335,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio label background on secondary"
       },
@@ -2344,7 +2344,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio label background on secondary"
         }
@@ -2361,7 +2361,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a checkbox or radio label background on secondary"
       },
@@ -2370,7 +2370,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a checkbox or radio label background on secondary"
         }
@@ -2387,7 +2387,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused state of a checkbox or radio label background on secondary"
       },
@@ -2396,7 +2396,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused state of a checkbox or radio label background on secondary"
         }
@@ -2413,7 +2413,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2422,7 +2422,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2439,7 +2439,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Default background color on form elements"
       },
@@ -2448,7 +2448,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Default background color on form elements"
         }
@@ -2465,7 +2465,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Error background color on form elements"
       },
@@ -2474,7 +2474,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Error background color on form elements"
         }
@@ -2491,7 +2491,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element background"
       },
@@ -2500,7 +2500,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element background"
         }
@@ -2517,7 +2517,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of a form element background"
       },
@@ -2526,7 +2526,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of a form element background"
         }
@@ -2543,7 +2543,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element background"
       },
@@ -2552,7 +2552,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element background"
         }
@@ -2569,7 +2569,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Active state of an input or select element background on secondary"
       },
@@ -2578,7 +2578,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Active state of an input or select element background on secondary"
         }
@@ -2595,7 +2595,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element background"
       },
@@ -2604,7 +2604,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element background"
         }
@@ -2621,7 +2621,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element background"
       },
@@ -2630,7 +2630,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element background"
         }
@@ -2647,7 +2647,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Selected focus state of checkbox or radio element background"
       },
@@ -2656,7 +2656,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Selected focus state of checkbox or radio element background"
         }
@@ -2673,7 +2673,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "input",
         "example": "color",
         "description": "Focused checkbox or radio form element background"
       },
@@ -2682,7 +2682,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "input",
           "example": "color",
           "description": "Focused checkbox or radio form element background"
         }
@@ -2699,7 +2699,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "The defaul background color of the rating star icon"
       },
@@ -2708,7 +2708,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "The defaul background color of the rating star icon"
         }
@@ -2725,7 +2725,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "rating",
         "example": "color",
         "description": "Background color for the highlighted rating icon"
       },
@@ -2734,7 +2734,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "rating",
           "example": "color",
           "description": "Background color for the highlighted rating icon"
         }
@@ -2751,7 +2751,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table headers"
       },
@@ -2760,7 +2760,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table headers"
         }
@@ -2777,7 +2777,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "The background color of table rows"
       },
@@ -2786,7 +2786,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "The background color of table rows"
         }
@@ -2803,7 +2803,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "background",
+        "type": "table",
         "example": "color",
         "description": "An alternate row color to aid grouping row data"
       },
@@ -2812,7 +2812,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "background",
+          "type": "table",
           "example": "color",
           "description": "An alternate row color to aid grouping row data"
         }
@@ -2829,7 +2829,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Background color for tooltips"
       },
@@ -2838,7 +2838,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Background color for tooltips"
         }
@@ -2855,7 +2855,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the primary button"
       },
@@ -2864,7 +2864,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the primary button"
         }
@@ -2881,7 +2881,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the primary button"
       },
@@ -2890,7 +2890,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the primary button"
         }
@@ -2907,7 +2907,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the primary button"
       },
@@ -2916,7 +2916,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the primary button"
         }
@@ -2933,7 +2933,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the primary button"
       },
@@ -2942,7 +2942,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the primary button"
         }
@@ -2959,7 +2959,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the secondary button"
       },
@@ -2968,7 +2968,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the secondary button"
         }
@@ -2985,7 +2985,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the secondary button"
       },
@@ -2994,7 +2994,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the secondary button"
         }
@@ -3011,7 +3011,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the secondary button"
       },
@@ -3020,7 +3020,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the secondary button"
         }
@@ -3037,7 +3037,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the secondary button"
       },
@@ -3046,7 +3046,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the secondary button"
         }
@@ -3063,7 +3063,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the dark button"
       },
@@ -3072,7 +3072,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the dark button"
         }
@@ -3089,7 +3089,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the dark button"
       },
@@ -3098,7 +3098,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the dark button"
         }
@@ -3115,7 +3115,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the dark button"
       },
@@ -3124,7 +3124,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the dark button"
         }
@@ -3141,7 +3141,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the dark button"
       },
@@ -3150,7 +3150,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the dark button"
         }
@@ -3167,7 +3167,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the sale button"
       },
@@ -3176,7 +3176,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the sale button"
         }
@@ -3193,7 +3193,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the active and pressed states of the sale button"
       },
@@ -3202,7 +3202,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the active and pressed states of the sale button"
         }
@@ -3219,7 +3219,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Inset border for the active state of the sale button"
       },
@@ -3228,7 +3228,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Inset border for the active state of the sale button"
         }
@@ -3245,7 +3245,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the hover state of the sale button"
       },
@@ -3254,7 +3254,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the hover state of the sale button"
         }
@@ -3271,7 +3271,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Default disabled border color"
       },
@@ -3280,7 +3280,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Default disabled border color"
         }
@@ -3297,7 +3297,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "button",
         "example": "color",
         "description": "Border color for the icon only button active and focus states"
       },
@@ -3306,7 +3306,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "button",
           "example": "color",
           "description": "Border color for the icon only button active and focus states"
         }
@@ -3323,7 +3323,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for chips"
       },
@@ -3332,7 +3332,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for chips"
         }
@@ -3349,7 +3349,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for disabled chips"
       },
@@ -3358,7 +3358,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for disabled chips"
         }
@@ -3375,7 +3375,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered chips"
       },
@@ -3384,7 +3384,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered chips"
         }
@@ -3401,7 +3401,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused chips"
       },
@@ -3410,7 +3410,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused chips"
         }
@@ -3427,7 +3427,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for active chips"
       },
@@ -3436,7 +3436,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for active chips"
         }
@@ -3453,7 +3453,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for selected chips"
       },
@@ -3462,7 +3462,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for selected chips"
         }
@@ -3479,7 +3479,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for hovered selected chips"
       },
@@ -3488,7 +3488,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for hovered selected chips"
         }
@@ -3505,7 +3505,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "chip",
         "example": "color",
         "description": "Border color for focused selected chips"
       },
@@ -3514,7 +3514,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "chip",
           "example": "color",
           "description": "Border color for focused selected chips"
         }
@@ -3687,7 +3687,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focused border color on checkbox or radio labels"
       },
@@ -3696,7 +3696,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focused border color on checkbox or radio labels"
         }
@@ -3713,7 +3713,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Default border color on form elements"
       },
@@ -3722,7 +3722,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Default border color on form elements"
         }
@@ -3739,7 +3739,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Error border color on form elements"
       },
@@ -3748,7 +3748,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Error border color on form elements"
         }
@@ -3765,7 +3765,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover/active/focus state of a checkbox or radio element border"
       },
@@ -3774,7 +3774,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover/active/focus state of a checkbox or radio element border"
         }
@@ -3791,7 +3791,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Selected state of a checkbox or radio element border"
       },
@@ -3800,7 +3800,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Selected state of a checkbox or radio element border"
         }
@@ -3817,7 +3817,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Focus state of an input or select element border"
       },
@@ -3826,7 +3826,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Focus state of an input or select element border"
         }
@@ -3843,7 +3843,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected checkbox or radio element border"
       },
@@ -3852,7 +3852,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected checkbox or radio element border"
         }
@@ -3869,7 +3869,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a checkbox or radio element border"
       },
@@ -3878,7 +3878,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a checkbox or radio element border"
         }
@@ -3895,7 +3895,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "input",
         "example": "color",
         "description": "Disabled form element border"
       },
@@ -3904,7 +3904,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "input",
           "example": "color",
           "description": "Disabled form element border"
         }
@@ -3921,7 +3921,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for underlined links"
       },
@@ -3930,7 +3930,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for underlined links"
         }
@@ -3947,7 +3947,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the hover state of underlined links"
       },
@@ -3956,7 +3956,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the hover state of underlined links"
         }
@@ -3973,7 +3973,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color for the active and pressed states of underlined links"
       },
@@ -3982,7 +3982,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color for the active and pressed states of underlined links"
         }
@@ -3999,7 +3999,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Disabled border color of underlined links"
       },
@@ -4008,7 +4008,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Disabled border color of underlined links"
         }
@@ -4025,7 +4025,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "link",
         "example": "color",
         "description": "Border color of visited underlined links"
       },
@@ -4034,7 +4034,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "link",
           "example": "color",
           "description": "Border color of visited underlined links"
         }
@@ -4051,7 +4051,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Default border color for the unhighlighted rating icon"
       },
@@ -4060,7 +4060,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Default border color for the unhighlighted rating icon"
         }
@@ -4077,7 +4077,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "rating",
         "example": "color",
         "description": "Border color for the highlighted rating icon"
       },
@@ -4086,7 +4086,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "rating",
           "example": "color",
           "description": "Border color for the highlighted rating icon"
         }
@@ -4103,7 +4103,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "The border color of tab keyline"
       },
@@ -4112,7 +4112,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "The border color of tab keyline"
         }
@@ -4129,7 +4129,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the active tab keyline"
       },
@@ -4138,7 +4138,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the active tab keyline"
         }
@@ -4155,7 +4155,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the active tab keyline"
       },
@@ -4164,7 +4164,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the active tab keyline"
         }
@@ -4181,7 +4181,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the tab keyline hover state"
       },
@@ -4190,7 +4190,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the tab keyline hover state"
         }
@@ -4207,7 +4207,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Alternative border color for the tab keyline hover state"
       },
@@ -4216,7 +4216,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Alternative border color for the tab keyline hover state"
         }
@@ -4233,7 +4233,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "tabs",
         "example": "color",
         "description": "Border color for the disabled tab keyline"
       },
@@ -4242,7 +4242,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "tabs",
           "example": "color",
           "description": "Border color for the disabled tab keyline"
         }
@@ -4259,7 +4259,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "The border color of table rows and their corresponding data cells"
       },
@@ -4268,7 +4268,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "The border color of table rows and their corresponding data cells"
         }
@@ -4285,7 +4285,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "border",
+        "type": "table",
         "example": "color",
         "description": "Border color separating complex table heads"
       },
@@ -4294,7 +4294,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "border",
+          "type": "table",
           "example": "color",
           "description": "Border color separating complex table heads"
         }
@@ -4311,7 +4311,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "text",
+        "type": "tooltip",
         "example": "color",
         "description": "Border color for tooltips"
       },
@@ -4320,7 +4320,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "text",
+          "type": "tooltip",
           "example": "color",
           "description": "Border color for tooltips"
         }
@@ -4441,7 +4441,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Rest state of a selected form icon"
       },
@@ -4450,7 +4450,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Rest state of a selected form icon"
         }
@@ -4467,7 +4467,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4476,7 +4476,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }
@@ -4493,7 +4493,7 @@
       "category": "color",
       "docs": {
         "category": "colors",
-        "type": "icon",
+        "type": "input",
         "example": "color",
         "description": "Hover state of a selected form icon"
       },
@@ -4502,7 +4502,7 @@
         "category": "color",
         "docs": {
           "category": "colors",
-          "type": "icon",
+          "type": "input",
           "example": "color",
           "description": "Hover state of a selected form icon"
         }

--- a/tokens/global/button.json5
+++ b/tokens/global/button.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for primary buttons',
           },
@@ -20,7 +20,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the hover state of primary buttons',
           },
@@ -30,7 +30,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the active state of primary buttons',
           },
@@ -40,7 +40,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for disabled primary buttons',
           },
@@ -50,7 +50,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for secondary buttons',
           },
@@ -60,7 +60,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the hover state of secondary buttons',
           },
@@ -70,7 +70,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the active state of secondary buttons',
           },
@@ -80,7 +80,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for disabled secondary buttons',
           },
@@ -91,7 +91,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the dark button',
           },
@@ -102,7 +102,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the hover state of the dark button',
           },
@@ -113,7 +113,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the active state of the dark button',
           },
@@ -124,7 +124,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for disabled dark buttons',
           },
@@ -135,7 +135,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the sale button',
           },
@@ -146,7 +146,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the hover state of the sale button',
           },
@@ -157,7 +157,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for the active state of the sale button',
           },
@@ -168,7 +168,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Text color for disabled sale buttons',
           },
@@ -184,7 +184,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the primary button',
             },
@@ -194,7 +194,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the active and pressed states of the primary button',
             },
@@ -204,7 +204,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the hover state of the primary button',
             },
@@ -214,7 +214,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Alternate background color for the hover state of the icon button',
             },
@@ -226,7 +226,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the secondary button',
             },
@@ -236,7 +236,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the active and pressed states of the secondary button',
             },
@@ -246,7 +246,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the hover state of the secondary button',
             },
@@ -256,7 +256,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the disabled state of the secondary button',
             },
@@ -268,7 +268,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the dark button',
             },
@@ -278,7 +278,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the active and pressed states of the dark button',
             },
@@ -288,7 +288,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the hover state of the dark button',
             },
@@ -300,7 +300,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the sale button',
             },
@@ -310,7 +310,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the active and pressed states of the sale button',
             },
@@ -320,7 +320,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'background',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Background color for the hover state of the sale button',
             },
@@ -331,7 +331,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Default disabled border color',
           },
@@ -341,7 +341,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Background color for the icon only button active and focus states',
           },
@@ -357,7 +357,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the primary button',
             },
@@ -367,7 +367,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the active and pressed states of the primary button',
             },
@@ -377,7 +377,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Inset border for the active state of the primary button',
             },
@@ -387,7 +387,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the hover state of the primary button',
             },
@@ -399,7 +399,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the secondary button',
             },
@@ -409,7 +409,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the active and pressed states of the secondary button',
             },
@@ -419,7 +419,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Inset border for the active state of the secondary button',
             },
@@ -429,7 +429,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the hover state of the secondary button',
             },
@@ -441,7 +441,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the dark button',
             },
@@ -451,7 +451,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the active and pressed states of the dark button',
             },
@@ -461,7 +461,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Inset border for the active state of the dark button',
             },
@@ -471,7 +471,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the hover state of the dark button',
             },
@@ -483,7 +483,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the sale button',
             },
@@ -493,7 +493,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the active and pressed states of the sale button',
             },
@@ -503,7 +503,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Inset border for the active state of the sale button',
             },
@@ -513,7 +513,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'button',
               example: '{color.docExample}',
               description: 'Border color for the hover state of the sale button',
             },
@@ -524,7 +524,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Default disabled border color',
           },
@@ -534,7 +534,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'button',
             example: '{color.docExample}',
             description: 'Border color for the icon only button active and focus states',
           },

--- a/tokens/global/chip.json5
+++ b/tokens/global/chip.json5
@@ -9,7 +9,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Text color for default chips',
           },
@@ -19,7 +19,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Text color for default chips',
           },
@@ -34,7 +34,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for chips',
           }
@@ -44,7 +44,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for disabled chips',
           }
@@ -54,7 +54,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for hovered chips',
           }
@@ -64,7 +64,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for focused chips',
           }
@@ -74,7 +74,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for active chips',
           }
@@ -84,7 +84,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for selected chips',
           }
@@ -94,7 +94,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for hovered selected chips',
           }
@@ -104,7 +104,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Background color for focused selected chips',
           }
@@ -119,7 +119,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for chips',
           }
@@ -129,7 +129,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for disabled chips',
           }
@@ -139,7 +139,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for hovered chips',
           }
@@ -149,7 +149,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for focused chips',
           }
@@ -159,7 +159,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for active chips',
           }
@@ -169,7 +169,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for selected chips',
           }
@@ -179,7 +179,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for hovered selected chips',
           }
@@ -189,7 +189,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'chip',
             example: '{color.docExample}',
             description: 'Border color for focused selected chips',
           }

--- a/tokens/global/color.json5
+++ b/tokens/global/color.json5
@@ -226,7 +226,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'accordion',
           example: '{color.docExample}',
           description: 'Background color for the hover state of accordion',
         },
@@ -236,7 +236,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'pagination',
           example: '{color.docExample}',
           description: 'Background color for the hover state of pagination',
         },
@@ -246,7 +246,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'pagination',
           example: '{color.docExample}',
           description: 'Background color for the pagination keyline',
         },
@@ -257,7 +257,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'modal',
           example: '{color.docExample}',
           description: 'The background overlay for modal',
         },

--- a/tokens/global/input.json5
+++ b/tokens/global/input.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Default text color used in form elements',
           },
@@ -20,7 +20,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Color of label text used in form elements',
           },
@@ -30,7 +30,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Color of label text used in disabled form elements',
           },
@@ -40,7 +40,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Text color of placeholder text within forms',
           },
@@ -50,7 +50,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Text color of required label within forms',
           },
@@ -60,7 +60,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Text color of optional label within forms',
           },
@@ -70,7 +70,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Disabled text color used in form elements',
           },
@@ -80,7 +80,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Text color used in filled forms',
           },
@@ -90,7 +90,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Help text color used in forms',
           },
@@ -100,7 +100,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Error text color used in forms',
           },
@@ -114,7 +114,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'icon',
+          type: 'input',
           example: '{color.docExample}',
           description: 'Rest state of a selected form icon',
         },
@@ -124,7 +124,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'icon',
+          type: 'input',
           example: '{color.docExample}',
           description: 'Hover state of a selected form icon',
         },
@@ -134,7 +134,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'icon',
+          type: 'input',
           example: '{color.docExample}',
           description: 'Hover state of a selected form icon',
         },
@@ -149,7 +149,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a checkbox or radio label background',
           },
@@ -159,7 +159,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Active state of a checkbox or radio label background',
           },
@@ -169,7 +169,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Focused state of a checkbox or radio label background',
           },
@@ -179,7 +179,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a checkbox or radio label background on secondary',
           },
@@ -189,7 +189,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Active state of a checkbox or radio label background on secondary',
           },
@@ -199,7 +199,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Focused state of a checkbox or radio label background on secondary',
           },
@@ -211,7 +211,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Default background color on form elements',
           },
@@ -221,7 +221,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Default background color on form elements',
           },
@@ -231,7 +231,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Error background color on form elements',
           },
@@ -241,7 +241,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a checkbox or radio element background',
           },
@@ -251,7 +251,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Active state of a form element background',
           },
@@ -261,7 +261,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Selected state of a checkbox or radio element background',
           },
@@ -271,7 +271,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Active state of an input or select element background on secondary',
           },
@@ -281,7 +281,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a selected checkbox or radio element background',
           },
@@ -291,7 +291,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Disabled form element background',
           },
@@ -301,7 +301,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Selected focus state of checkbox or radio element background',
           },
@@ -311,7 +311,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'background',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Focused checkbox or radio form element background',
           },
@@ -326,7 +326,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Focused border color on checkbox or radio labels',
           },
@@ -338,7 +338,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Default border color on form elements',
           },
@@ -348,7 +348,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Error border color on form elements',
           },
@@ -358,7 +358,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover/active/focus state of a checkbox or radio element border',
           },
@@ -368,7 +368,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Selected state of a checkbox or radio element border',
           },
@@ -378,7 +378,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Focus state of an input or select element border',
           },
@@ -388,7 +388,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a selected checkbox or radio element border',
           },
@@ -398,7 +398,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Hover state of a checkbox or radio element border',
           },
@@ -408,7 +408,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'input',
             example: '{color.docExample}',
             description: 'Disabled form element border',
           },

--- a/tokens/global/link.json5
+++ b/tokens/global/link.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Text color for links',
           },
@@ -20,7 +20,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Text color for the hover state of links',
           },
@@ -30,7 +30,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Text color for the active and pressed states of links',
           },
@@ -40,7 +40,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Disabled text color of links',
           },
@@ -50,7 +50,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Text color of visited links',
           },
@@ -65,7 +65,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Border color for underlined links',
           },
@@ -75,7 +75,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Border color for the hover state of underlined links',
           },
@@ -85,7 +85,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Border color for the active and pressed states of underlined links',
           },
@@ -95,7 +95,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Disabled border color of underlined links',
           },
@@ -105,7 +105,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'link',
             example: '{color.docExample}',
             description: 'Border color of visited underlined links',
           },

--- a/tokens/global/rating.json5
+++ b/tokens/global/rating.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'rating',
             example: '{color.docExample}',
             description: 'Text color for ratings',
           },
@@ -20,7 +20,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'rating',
             example: '{color.docExample}',
             description: 'Text color for the hover state of ratings',
           },
@@ -30,7 +30,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'rating',
             example: '{color.docExample}',
             description: 'Text color for the separator in ratings',
           },
@@ -44,7 +44,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'rating',
           example: '{color.docExample}',
           description: 'The defaul background color of the rating star icon',
         },
@@ -54,7 +54,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'rating',
           example: '{color.docExample}',
           description: 'Background color for the highlighted rating icon',
         },
@@ -68,7 +68,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'rating',
             example: '{color.docExample}',
             description: 'Default border color for the unhighlighted rating icon',
           },
@@ -78,7 +78,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'rating',
             example: '{color.docExample}',
             description: 'Border color for the highlighted rating icon',
           },

--- a/tokens/global/tab.json5
+++ b/tokens/global/tab.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tabs',
             example: '{color.docExample}',
             description: 'Text color for tabs',
           },
@@ -20,7 +20,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tabs',
             example: '{color.docExample}',
             description: 'Text color for the active and pressed states of tabs',
           },
@@ -30,7 +30,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tabs',
             example: '{color.docExample}',
             description: 'Text color for the hover state of tabs',
           },
@@ -40,7 +40,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tabs',
             example: '{color.docExample}',
             description: 'Disabled text color of tabs',
           },
@@ -57,7 +57,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'The border color of tab keyline',
             },
@@ -67,7 +67,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'Border color for the active tab keyline',
             },
@@ -77,7 +77,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'Alternative border color for the active tab keyline',
             },
@@ -87,7 +87,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'Border color for the tab keyline hover state',
             },
@@ -97,7 +97,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'Alternative border color for the tab keyline hover state',
             },
@@ -107,7 +107,7 @@
             category: 'color',
             docs: {
               category: '{color.docCategory}',
-              type: 'border',
+              type: 'tabs',
               example: '{color.docExample}',
               description: 'Border color for the disabled tab keyline',
             },

--- a/tokens/global/table.json5
+++ b/tokens/global/table.json5
@@ -8,7 +8,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'table',
           example: '{color.docExample}',
           description: 'The background color of table headers',
         },
@@ -18,7 +18,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'table',
           example: '{color.docExample}',
           description: 'The background color of table rows',
         },
@@ -28,7 +28,7 @@
         category: 'color',
         docs: {
           category: '{color.docCategory}',
-          type: 'background',
+          type: 'table',
           example: '{color.docExample}',
           description: 'An alternate row color to aid grouping row data',
         },
@@ -41,7 +41,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'table',
             example: '{color.docExample}',
             description: 'The border color of table rows and their corresponding data cells',
           },
@@ -51,7 +51,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'border',
+            type: 'table',
             example: '{color.docExample}',
             description: 'Border color separating complex table heads',
           },

--- a/tokens/global/tooltip.json5
+++ b/tokens/global/tooltip.json5
@@ -10,7 +10,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tooltip',
             example: '{color.docExample}',
             description: 'Text color for tooltips',
           }
@@ -25,7 +25,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tooltip',
             example: '{color.docExample}',
             description: 'Background color for tooltips',
           }
@@ -40,7 +40,7 @@
           category: 'color',
           docs: {
             category: '{color.docCategory}',
-            type: 'text',
+            type: 'tooltip',
             example: '{color.docExample}',
             description: 'Border color for tooltips',
           }


### PR DESCRIPTION
https://rei.github.io/rei-cedar-docs/tokens/all-tokens/ 

updates docs type for all of the component-specific tokens so we can list them separately on the doc site. 