### PR TITLE
Split container mixins

### DIFF
--- a/dist/less/cdr-tokens.less
+++ b/dist/less/cdr-tokens.less
@@ -1317,29 +1317,31 @@
   }
 }
 
-.cdr-container() {
-  .cdr-text-default();
-  margin-left: auto;
-  margin-right: auto;
+.cdr-container-base() {
   padding-left: @cdr-space-one-x;
   padding-right: @cdr-space-one-x;
   width: 100%;
-  max-width: @cdr-breakpoint-lg;
   .cdr-md-mq-up({
     padding-left: @cdr-space-two-x;
     padding-right: @cdr-space-two-x;
   });
 }
 
+.cdr-container-static() {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: @cdr-breakpoint-lg;
+}
+
+.cdr-container() {
+  .cdr-text-default();
+  .cdr-container-base();
+  .cdr-container-static();
+}
+
 .cdr-container-fluid() {
   .cdr-text-default();
-  padding-left: @cdr-space-one-x;
-  padding-right: @cdr-space-one-x;
-  width: 100%;
-  .cdr-md-mq-up({
-    padding-left: @cdr-space-two-x;
-    padding-right: @cdr-space-two-x;
-  });
+  .cdr-container-base();
 }
 
 // XS

--- a/dist/scss/cdr-tokens.scss
+++ b/dist/scss/cdr-tokens.scss
@@ -1939,29 +1939,31 @@ $cdr-text-strong-weight: 700;
   }
 }
 
-@mixin cdr-container {
-  @include cdr-text-default;
-  margin-left: auto;
-  margin-right: auto;
+@mixin cdr-container-base {
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
-  max-width: $cdr-breakpoint-lg;
   @include cdr-md-mq-up {
     padding-left: $cdr-space-two-x;
     padding-right: $cdr-space-two-x;
   }
 }
 
+@mixin cdr-container-static {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: $cdr-breakpoint-lg;
+}
+
+@mixin cdr-container {
+  @include cdr-text-default;
+  @include cdr-container-base;
+  @include cdr-container-static;
+}
+
 @mixin cdr-container-fluid {
   @include cdr-text-default;
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-  @include cdr-md-mq-up {
-    padding-left: $cdr-space-two-x;
-    padding-right: $cdr-space-two-x;
-  }
+  @include cdr-container-base;
 }
 
 // XS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "9.0.0-alpha.1",
+  "version": "9.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-tokens",
-  "version": "9.0.0-alpha.1",
+  "version": "9.0.0-beta.1",
   "description": "Tokens for REI cedar design system",
   "author": "REI Software Engineering",
   "homepage": "https://rei.github.io/rei-cedar-tokens/#/",

--- a/style-dictionary/utilities/display.less
+++ b/style-dictionary/utilities/display.less
@@ -23,27 +23,29 @@
   }
 }
 
-.cdr-container() {
-  .cdr-text-default();
-  margin-left: auto;
-  margin-right: auto;
+.cdr-container-base() {
   padding-left: @cdr-space-one-x;
   padding-right: @cdr-space-one-x;
   width: 100%;
-  max-width: @cdr-breakpoint-lg;
   .cdr-md-mq-up({
     padding-left: @cdr-space-two-x;
     padding-right: @cdr-space-two-x;
   });
 }
 
+.cdr-container-static() {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: @cdr-breakpoint-lg;
+}
+
+.cdr-container() {
+  .cdr-text-default();
+  .cdr-container-base();
+  .cdr-container-static();
+}
+
 .cdr-container-fluid() {
   .cdr-text-default();
-  padding-left: @cdr-space-one-x;
-  padding-right: @cdr-space-one-x;
-  width: 100%;
-  .cdr-md-mq-up({
-    padding-left: @cdr-space-two-x;
-    padding-right: @cdr-space-two-x;
-  });
+  .cdr-container-base();
 }

--- a/style-dictionary/utilities/display.scss
+++ b/style-dictionary/utilities/display.scss
@@ -46,27 +46,29 @@
   }
 }
 
-@mixin cdr-container {
-  @include cdr-text-default;
-  margin-left: auto;
-  margin-right: auto;
+@mixin cdr-container-base {
   padding-left: $cdr-space-one-x;
   padding-right: $cdr-space-one-x;
   width: 100%;
-  max-width: $cdr-breakpoint-lg;
   @include cdr-md-mq-up {
     padding-left: $cdr-space-two-x;
     padding-right: $cdr-space-two-x;
   }
 }
 
+@mixin cdr-container-static {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: $cdr-breakpoint-lg;
+}
+
+@mixin cdr-container {
+  @include cdr-text-default;
+  @include cdr-container-base;
+  @include cdr-container-static;
+}
+
 @mixin cdr-container-fluid {
   @include cdr-text-default;
-  padding-left: $cdr-space-one-x;
-  padding-right: $cdr-space-one-x;
-  width: 100%;
-  @include cdr-md-mq-up {
-    padding-left: $cdr-space-two-x;
-    padding-right: $cdr-space-two-x;
-  }
+  @include cdr-container-base;
 }


### PR DESCRIPTION
makes it easier to create an optimized `cdr-container` component that just adds these mixins to a plain container