### PR TITLE
fix: await token concat before cleanup

### DIFF
--- a/style-dictionary/actions/concat-files.ts
+++ b/style-dictionary/actions/concat-files.ts
@@ -63,7 +63,7 @@ const createImportLine = (fileExtension: string, filePath: string): string => {
 export const concatFiles = (sd: typeof StyleDictionary): void => {
   sd.registerAction({
     name: 'concat-files',
-    do: (_, config): void => {
+    do: async (_, config): Promise<void> => {
       try {
         if (!config.buildPath) {
           console.warn('No buildPath specified in the configuration.');
@@ -96,24 +96,24 @@ export const concatFiles = (sd: typeof StyleDictionary): void => {
           fs.renameSync(p, newPath);
         });
 
-        // Concatenate files
-        concat(concatPaths).then((r: unknown) => {
-          const outFile = path.join(
-            __dirname,
-            '../../',
-            config.buildPath!,
-            `cdr-tokens${extension}`
-          );
+        // Concatenate files before removing the source files.
+        const r = await concat(concatPaths);
 
-          const importLines = createImportLine(extension, outFile);
-          const finalOuput = extension.includes('less')
-            ? (r as string)
-            : `${importLines}\n\n${r as string}`;
+        const outFile = path.join(
+          __dirname,
+          '../../',
+          config.buildPath!,
+          `cdr-tokens${extension}`
+        );
 
-          fs.outputFileSync(outFile, finalOuput);
-        });
+        const importLines = createImportLine(extension, outFile);
+        const finalOuput = extension.includes('less')
+          ? (r as string)
+          : `${importLines}\n\n${r as string}`;
 
-        // Remove concatenated files
+        fs.outputFileSync(outFile, finalOuput);
+
+        // Remove concatenated files after writing the output file.
         concatPaths.forEach((p) => {
           fs.removeSync(p);
         });


### PR DESCRIPTION
## Summary

Fixes a race in the custom Style Dictionary `concat-files` action.

The action previously started `concat(...)` asynchronously and then immediately deleted the source files. In CI this could fail with `ENOENT` while processing later platforms because generated files like `dist/rei-dot-com/scss/cdr-variable.scss` could be removed before the concat promise finished reading and writing output.

## Change

- make the action `async`
- `await concat(concatPaths)` before writing the combined output
- only remove source files after the output file has been written

## Validation

- ✅ `pnpm build` passes on a clean branch from `origin/next`
- ✅ `validate` passes as part of the full build

## Notes

The branch hook chain on `next` is currently broken for normal commits because:
- `pre-commit` invokes `prettier`, which is not available in this branch context
- `prepare-commit-msg` launches Commitizen interactively

That is separate from this build fix.