### PR TITLE
fix: correct code samples in ConsumerTypeScriptContract stories

### DIFF
--- a/dist/docsite/json/platform-tokens.json
+++ b/dist/docsite/json/platform-tokens.json
@@ -1,0 +1,24387 @@
+{
+  "global": {
+    "misc": [
+      {
+        "$type": "string",
+        "$value": "10",
+        "filePath": "tokens/_options/base.json",
+        "isSource": false,
+        "original": {
+          "$type": "string",
+          "$value": "10px"
+        },
+        "name": "cdr-text-size-root",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text-size-root}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "type": "code-snippet"
+        },
+        "filePath": "tokens/themes/docsite/code-snippet.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "type": "code-snippet"
+          }
+        },
+        "name": "cdr-color-background-code-snippet",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.code-snippet}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "code-snippet"
+        },
+        "filePath": "tokens/themes/docsite/code.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "code-snippet"
+          }
+        },
+        "name": "cdr-color-background-code",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.code}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-color-background-link-card-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.link-card.rest}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-color-background-link-card-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.link-card.active}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-color-background-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.note}"
+      },
+      {
+        "$value": "#c4b03b",
+        "$type": "color",
+        "docs": {
+          "type": "background"
+        },
+        "filePath": "tokens/themes/docsite/tag.json",
+        "isSource": true,
+        "original": {
+          "$value": "{theme.color.primary-100}",
+          "$type": "color",
+          "docs": {
+            "type": "background"
+          }
+        },
+        "name": "cdr-color-background-tag",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.tag}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.9)",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-90}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-color-text-table-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.table.primary}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-color-text-table-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.table.secondary}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-color-text-usage-affirmative",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.usage.affirmative}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-color-text-usage-negative",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.usage.negative}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-color-text-usage-caution",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.usage.caution}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-color-border-table-row",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.table.row}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "type": "code-snippet"
+        },
+        "filePath": "tokens/themes/docsite/code.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "type": "code-snippet"
+          }
+        },
+        "name": "cdr-color-border-code",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.code}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-color-border-link-card-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link-card.hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-color-border-link-card-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link-card.active}"
+      },
+      {
+        "$value": "#c4b03b",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{theme.color.primary-100}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-color-border-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.note}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "type": "border"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "type": "border"
+          }
+        },
+        "name": "cdr-color-border-usage-affirmative",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.usage.affirmative}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "type": "border"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "type": "border"
+          }
+        },
+        "name": "cdr-color-border-usage-negative",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.usage.negative}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "type": "border"
+        },
+        "filePath": "tokens/themes/docsite/usage.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "type": "border"
+          }
+        },
+        "name": "cdr-color-border-usage-caution",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.usage.caution}"
+      },
+      {
+        "$value": "#c4b03b",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{theme.color.primary-100}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-color-icon-background-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon-background.note}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "code-snippet"
+        },
+        "filePath": "tokens/themes/docsite/code-snippet.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "code-snippet"
+          }
+        },
+        "name": "cdr-knockout-background-code-snippet",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.background.code-snippet}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-text-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.text.primary}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-text-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.text.secondary}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-knockout-color-text-table-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.text.table.primary}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-knockout-color-text-table-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.text.table.secondary}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-background-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.primary}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-knockout-color-background-link-card-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.link-card.rest}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-knockout-color-background-link-card-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.link-card.active}"
+      },
+      {
+        "$value": "rgba(75, 74, 72, 0.5)",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900-50}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-knockout-color-background-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.note}"
+      },
+      {
+        "$value": "rgba(75, 74, 72, 0.5)",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900-50}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-knockout-color-background-table-header",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.table.header}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-knockout-color-background-table-row",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.background.table.row}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-border-inverse-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.inverse.primary}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-border-inverse-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.inverse.secondary}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-knockout-color-border-link-card-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.link-card.hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "link-card"
+        },
+        "filePath": "tokens/themes/docsite/link-card.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "link-card"
+          }
+        },
+        "name": "cdr-knockout-color-border-link-card-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.link-card.active}"
+      },
+      {
+        "$value": "#c4b03b",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{theme.color.primary-100}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-knockout-color-border-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.note}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "type": "table"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "type": "table"
+          }
+        },
+        "name": "cdr-knockout-color-border-table-row",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.border.table.row}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "type": "text"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "type": "text"
+          }
+        },
+        "name": "cdr-knockout-color-icon-inverse-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.icon.inverse.default}"
+      },
+      {
+        "$value": "#c4b03b",
+        "$type": "color",
+        "docs": {
+          "type": "note"
+        },
+        "filePath": "tokens/themes/docsite/note.json",
+        "isSource": true,
+        "original": {
+          "$value": "{theme.color.primary-100}",
+          "$type": "color",
+          "docs": {
+            "type": "note"
+          }
+        },
+        "name": "cdr-knockout-color-icon-background-note",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{knockout.color.icon-background.note}"
+      }
+    ],
+    "colors": [
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "accordion",
+          "example": "color",
+          "description": "Background color for the hover state of accordion"
+        },
+        "filePath": "tokens/global/accordion.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "accordion",
+            "example": "color",
+            "description": "Background color for the hover state of accordion"
+          }
+        },
+        "name": "cdr-color-background-accordion-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.accordion.hover}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-rest}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-active}"
+      },
+      {
+        "$value": "#c7dfd1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sage-green-400}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Alternate background color for the hover state of the icon button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Alternate background color for the hover state of the icon button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-icon-alt-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-icon-alt-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-active}"
+      },
+      {
+        "$value": "#f9f8f6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the disabled state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the disabled state of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-active}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-hover}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-rest}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-active}"
+      },
+      {
+        "$value": "#fde2e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Default disabled border color"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Default disabled border color"
+          }
+        },
+        "name": "cdr-color-background-button-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.default-disabled}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the icon only button active and focus states"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the icon only button active and focus states"
+          }
+        },
+        "name": "cdr-color-background-button-icon-only-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.icon-only-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for disabled chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for disabled chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-disabled}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for hovered chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for hovered chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for focused chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for focused chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-focus}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for active chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for active chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for hovered selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for hovered selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for focused selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for focused selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "A transparent color option"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.transparent}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "A transparent color option"
+          }
+        },
+        "name": "cdr-color-background-transparent",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.transparent}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "The default, primary background color of most pages"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "The default, primary background color of most pages"
+          }
+        },
+        "name": "cdr-color-background-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.primary}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "An alternate, secondary background color used on some pages"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "An alternate, secondary background color used on some pages"
+          }
+        },
+        "name": "cdr-color-background-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.secondary}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for sale messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for sale messages"
+          }
+        },
+        "name": "cdr-color-background-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.sale}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "An alternate, spruce brand background color used on some pages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "An alternate, spruce brand background color used on some pages"
+          }
+        },
+        "name": "cdr-color-background-brand-spruce",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.brand-spruce}"
+      },
+      {
+        "$value": "#ecf9e6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for success messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for success messages"
+          }
+        },
+        "name": "cdr-color-background-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.success}"
+      },
+      {
+        "$value": "#e2f4fe",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for informational messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for informational messages"
+          }
+        },
+        "name": "cdr-color-background-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.info}"
+      },
+      {
+        "$value": "#fdf6e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for warning messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for warning messages"
+          }
+        },
+        "name": "cdr-color-background-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.warning}"
+      },
+      {
+        "$value": "#fcefe4",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for error messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for error messages"
+          }
+        },
+        "name": "cdr-color-background-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.error}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-hover}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-active}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-active}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-focus}"
+      },
+      {
+        "$value": "rgba(247, 245, 243, 0.15)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025-15}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.85)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-85}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.secondary}"
+      },
+      {
+        "$value": "rgba(255, 242, 242, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-050-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.error}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected state of a checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected state of a checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of an input or select element background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of an input or select element background on secondary"
+          }
+        },
+        "name": "cdr-color-background-input-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.secondary-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected focus state of checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected focus state of checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected-focus}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused checkbox or radio form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused checkbox or radio form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-focus}"
+      },
+      {
+        "$value": "#f9f8f6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for default messages"
+          }
+        },
+        "name": "cdr-color-background-message-default-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.default-01}"
+      },
+      {
+        "$value": "#e8e0ce",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for default messages"
+          }
+        },
+        "name": "cdr-color-background-message-default-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.default-02}"
+      },
+      {
+        "$value": "#ecf9e6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success}"
+      },
+      {
+        "$value": "#f4fbf5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success-01}"
+      },
+      {
+        "$value": "#d5e6cb",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success-02}"
+      },
+      {
+        "$value": "#fdf6e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning}"
+      },
+      {
+        "$value": "#fefcf1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning-01}"
+      },
+      {
+        "$value": "#f5e9b7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning-02}"
+      },
+      {
+        "$value": "#fcefe4",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error}"
+      },
+      {
+        "$value": "#fdf7f7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error-01}"
+      },
+      {
+        "$value": "#eecbc1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error-02}"
+      },
+      {
+        "$value": "#e2f4fe",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info}"
+      },
+      {
+        "$value": "#edf4f5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info-01}"
+      },
+      {
+        "$value": "#c2d8db",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info-02}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for sale messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for sale messages"
+          }
+        },
+        "name": "cdr-color-background-message-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.sale}"
+      },
+      {
+        "$value": "rgba(247, 245, 243, 0.85)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "modal",
+          "example": "color",
+          "description": "The background overlay for modal"
+        },
+        "filePath": "tokens/global/modal.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025-85}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "modal",
+            "example": "color",
+            "description": "The background overlay for modal"
+          }
+        },
+        "name": "cdr-color-background-modal-overlay",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.modal.overlay}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "pagination",
+          "example": "color",
+          "description": "Background color for the hover state of pagination"
+        },
+        "filePath": "tokens/global/pagination.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "pagination",
+            "example": "color",
+            "description": "Background color for the hover state of pagination"
+          }
+        },
+        "name": "cdr-color-background-pagination-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.pagination.hover}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "pagination",
+          "example": "color",
+          "description": "Background color for the pagination keyline"
+        },
+        "filePath": "tokens/global/pagination.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "pagination",
+            "example": "color",
+            "description": "Background color for the pagination keyline"
+          }
+        },
+        "name": "cdr-color-background-pagination-keyline",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.pagination.keyline}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "The defaul background color of the rating star icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "The defaul background color of the rating star icon"
+          }
+        },
+        "name": "cdr-color-background-rating-star-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.rating-star.default}"
+      },
+      {
+        "$value": "#ffd280",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Background color for the highlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.golden-yellow-500}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Background color for the highlighted rating icon"
+          }
+        },
+        "name": "cdr-color-background-rating-star-highlighted",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.rating-star.highlighted}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the active state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the active state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the hover state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the hover state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the checked state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the checked state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-checked",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-checked}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the disabled state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the disabled state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-disabled}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the loading state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the loading state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-loading",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-loading}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the primary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the primary surface"
+          }
+        },
+        "name": "cdr-color-background-surface-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.primary}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the secondary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the secondary surface"
+          }
+        },
+        "name": "cdr-color-background-surface-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.secondary}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the brand-spruce surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the brand-spruce surface"
+          }
+        },
+        "name": "cdr-color-background-surface-brand-spruce",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.brand-spruce}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the sale surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the sale surface"
+          }
+        },
+        "name": "cdr-color-background-surface-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.sale}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-rest}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-focus}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Background color of a switch handle background when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Background color of a switch handle background when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-rest}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-focus}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-focus}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The background color of table headers"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The background color of table headers"
+          }
+        },
+        "name": "cdr-color-background-table-header",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.header}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The background color of table rows"
+        },
+        "filePath": "tokens/themes/docsite/table.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The background color of table rows"
+          }
+        },
+        "name": "cdr-color-background-table-row",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.row}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "An alternate row color to aid grouping row data"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "An alternate row color to aid grouping row data"
+          }
+        },
+        "name": "cdr-color-background-table-row-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.row-alt}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle group",
+          "example": "color",
+          "description": "The background color of a toggle group on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle group",
+            "example": "color",
+            "description": "The background color of a toggle group on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-group-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-group.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-rest}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on hover"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on hover"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-hover}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on focus"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-focus}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a selected toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a selected toggle button on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-selected-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a selected toggle button on hover"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a selected toggle button on hover"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-selected-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Background color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Background color for tooltips"
+          }
+        },
+        "name": "cdr-color-background-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.tooltip.default}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-disabled}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled dark buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled dark buttons"
+          }
+        },
+        "name": "cdr-color-text-button-dark-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-disabled}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled sale buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled sale buttons"
+          }
+        },
+        "name": "cdr-color-text-button-sale-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Text color for default chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Text color for default chips"
+          }
+        },
+        "name": "cdr-color-text-chip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.chip.default}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Text color for default chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Text color for default chips"
+          }
+        },
+        "name": "cdr-color-text-chip-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.chip.disabled}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.9)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The default, primary text color"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-90}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The default, primary text color"
+          }
+        },
+        "name": "cdr-color-text-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.primary}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The secondary text color"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The secondary text color"
+          }
+        },
+        "name": "cdr-color-text-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.secondary}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The emphasis text color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The emphasis text color"
+          }
+        },
+        "name": "cdr-color-text-emphasis",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.emphasis}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Text set in our primary brand color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Text set in our primary brand color"
+          }
+        },
+        "name": "cdr-color-text-brand",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.brand}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The color of sale text"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The color of sale text"
+          }
+        },
+        "name": "cdr-color-text-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.sale}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Text color on dark background"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Text color on dark background"
+          }
+        },
+        "name": "cdr-color-text-inverse",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.inverse}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The color of text when it is disabled"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The color of text when it is disabled"
+          }
+        },
+        "name": "cdr-color-text-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.disabled}"
+      },
+      {
+        "$value": "#2e6b34",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of success messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of success messages"
+          }
+        },
+        "name": "cdr-color-text-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.success}"
+      },
+      {
+        "$value": "#854714",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of warning messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of warning messages"
+          }
+        },
+        "name": "cdr-color-text-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.warning}"
+      },
+      {
+        "$value": "#811823",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of error messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of error messages"
+          }
+        },
+        "name": "cdr-color-text-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.error}"
+      },
+      {
+        "$value": "#1b437e",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of informational messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of informational messages"
+          }
+        },
+        "name": "cdr-color-text-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.info}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default text color used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default text color used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.default}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Color of label text used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Color of label text used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-label",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.label}"
+      },
+      {
+        "$value": "#b2ab9f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Color of label text used in disabled form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-450}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Color of label text used in disabled form elements"
+          }
+        },
+        "name": "cdr-color-text-input-label-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.label-disabled}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of placeholder text within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of placeholder text within forms"
+          }
+        },
+        "name": "cdr-color-text-input-placeholder",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.placeholder}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of required label within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of required label within forms"
+          }
+        },
+        "name": "cdr-color-text-input-required",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.required}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of optional label within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of optional label within forms"
+          }
+        },
+        "name": "cdr-color-text-input-optional",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.optional}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled text color used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled text color used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.disabled}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color used in filled forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color used in filled forms"
+          }
+        },
+        "name": "cdr-color-text-input-filled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.filled}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Help text color used in forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Help text color used in forms"
+          }
+        },
+        "name": "cdr-color-text-input-help",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.help}"
+      },
+      {
+        "$value": "#b33322",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error text color used in forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-850}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error text color used in forms"
+          }
+        },
+        "name": "cdr-color-text-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.error}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.9)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for links"
+        },
+        "filePath": "tokens/themes/docsite/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-90}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for links"
+          }
+        },
+        "name": "cdr-color-text-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.rest}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.9)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the hover state of links"
+        },
+        "filePath": "tokens/themes/docsite/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-90}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the hover state of links"
+          }
+        },
+        "name": "cdr-color-text-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the active and pressed states of links"
+        },
+        "filePath": "tokens/themes/docsite/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the active and pressed states of links"
+          }
+        },
+        "name": "cdr-color-text-link-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Disabled text color of links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Disabled text color of links"
+          }
+        },
+        "name": "cdr-color-text-link-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.disabled}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color of visited links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color of visited links"
+          }
+        },
+        "name": "cdr-color-text-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.visited}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of error messages"
+          }
+        },
+        "name": "cdr-color-text-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.message.error}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.default}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for the hover state of ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for the hover state of ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.hover}"
+      },
+      {
+        "$value": "#b2ab9f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for the separator in ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-450}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for the separator in ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-separator",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.separator}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for the active and pressed states of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for the active and pressed states of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.active}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for the hover state of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for the hover state of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Disabled text color of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Disabled text color of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The text color of a toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The text color of a toggle button on rest"
+          }
+        },
+        "name": "cdr-color-text-toggle-button-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.toggle-button.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Text color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Text color for tooltips"
+          }
+        },
+        "name": "cdr-color-text-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tooltip.default}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-rest}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-active}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-active-inset}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-hover}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-active}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-active-inset}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-active}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-active-inset}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-hover}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-rest}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-active}"
+      },
+      {
+        "$value": "#fde2e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-active-inset}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Default disabled border color"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Default disabled border color"
+          }
+        },
+        "name": "cdr-color-border-button-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the icon only button active and focus states"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the icon only button active and focus states"
+          }
+        },
+        "name": "cdr-color-border-button-icon-only-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.icon-only-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for disabled chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for disabled chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for hovered chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for hovered chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for focused chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for focused chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for active chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for active chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-rest}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for hovered selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for hovered selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for focused selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for focused selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "A transparent color option"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.transparent}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "A transparent color option"
+          }
+        },
+        "name": "cdr-color-border-transparent",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.transparent}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Default border color for separating content"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Default border color for separating content"
+          }
+        },
+        "name": "cdr-color-border-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.primary}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "An alternate, secondary background color used on some pages"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "An alternate, secondary background color used on some pages"
+          }
+        },
+        "name": "cdr-color-border-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.secondary}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for success elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for success elements"
+          }
+        },
+        "name": "cdr-color-border-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for warning elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for warning elements"
+          }
+        },
+        "name": "cdr-color-border-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for error elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for error elements"
+          }
+        },
+        "name": "cdr-color-border-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.error}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for informational elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for informational elements"
+          }
+        },
+        "name": "cdr-color-border-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.info}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused border color on checkbox or radio labels"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused border color on checkbox or radio labels"
+          }
+        },
+        "name": "cdr-color-border-label-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.label.default-focus}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default border color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default border color on form elements"
+          }
+        },
+        "name": "cdr-color-border-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default}"
+      },
+      {
+        "$value": "#b33322",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error border color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-850}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error border color on form elements"
+          }
+        },
+        "name": "cdr-color-border-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.error}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover/active/focus state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover/active/focus state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-selected}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focus state of an input or select element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focus state of an input or select element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-selected-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled form element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled form element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-disabled}"
+      },
+      {
+        "$value": "#000000",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for underlined links"
+        },
+        "filePath": "tokens/themes/docsite/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.black}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.rest}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the hover state of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the hover state of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.hover}"
+      },
+      {
+        "$value": "#0b2d60",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the active and pressed states of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the active and pressed states of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Disabled border color of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Disabled border color of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.disabled}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color of visited underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color of visited underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.visited}"
+      },
+      {
+        "$value": "#726d64",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for default messages"
+          }
+        },
+        "name": "cdr-color-border-message-default-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.default-01}"
+      },
+      {
+        "$value": "#e8e0ce",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for default messages"
+          }
+        },
+        "name": "cdr-color-border-message-default-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.default-02}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for success messages"
+          }
+        },
+        "name": "cdr-color-border-message-success-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.success-01}"
+      },
+      {
+        "$value": "#d5e6cb",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for success messages"
+          }
+        },
+        "name": "cdr-color-border-message-success-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.success-02}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-border-message-warning-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.warning-01}"
+      },
+      {
+        "$value": "#f5e9b7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-border-message-warning-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.warning-02}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for error messages"
+          }
+        },
+        "name": "cdr-color-border-message-error-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.error-01}"
+      },
+      {
+        "$value": "#eecbc1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for error messages"
+          }
+        },
+        "name": "cdr-color-border-message-error-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.error-02}"
+      },
+      {
+        "$value": "#408e86",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-border-message-info-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.info-01}"
+      },
+      {
+        "$value": "#c2d8db",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-border-message-info-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.info-02}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Default border color for the unhighlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Default border color for the unhighlighted rating icon"
+          }
+        },
+        "name": "cdr-color-border-rating-star-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.rating-star.default}"
+      },
+      {
+        "$value": "#bd7b2d",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Border color for the highlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.golden-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Border color for the highlighted rating icon"
+          }
+        },
+        "name": "cdr-color-border-rating-star-highlighted",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.rating-star.highlighted}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the active state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the active state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the hover state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the hover state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the checked state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the checked state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-checked",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-checked}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the disabled state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the disabled state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the loading state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the loading state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-loading",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-loading}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the primary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the primary surface"
+          }
+        },
+        "name": "cdr-color-border-surface-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.primary}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the secondary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the secondary surface"
+          }
+        },
+        "name": "cdr-color-border-surface-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.secondary}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the success surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the success surface"
+          }
+        },
+        "name": "cdr-color-border-surface-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the warning surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the warning surface"
+          }
+        },
+        "name": "cdr-color-border-surface-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the error surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the error surface"
+          }
+        },
+        "name": "cdr-color-border-surface-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.error}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the info surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the info surface"
+          }
+        },
+        "name": "cdr-color-border-surface-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.info}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Border color for a switch that is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Border color for a switch that is not selected on hover"
+          }
+        },
+        "name": "cdr-color-border-switch-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-focus}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "The border color of tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "The border color of tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-rest}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the active tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the active tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-active}"
+      },
+      {
+        "$value": "#78b1e8",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Alternative border color for the active tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Alternative border color for the active tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-active-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-active-alt}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the tab keyline hover state"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the tab keyline hover state"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-hover}"
+      },
+      {
+        "$value": "#78b1e8",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Alternative border color for the tab keyline hover state"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Alternative border color for the tab keyline hover state"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-hover-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-hover-alt}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the disabled tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the disabled tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-disabled}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The border color of table rows and their corresponding data cells"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The border color of table rows and their corresponding data cells"
+          }
+        },
+        "name": "cdr-color-border-table-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.table.default}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "Border color separating complex table heads"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "Border color separating complex table heads"
+          }
+        },
+        "name": "cdr-color-border-table-head",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.table.head}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a toggle button that is not selected on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a toggle button that is not selected on focus"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a selected toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a selected toggle button on rest"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-selected-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a selected toggle on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a selected toggle on focus"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-selected-focus}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Border color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Border color for tooltips"
+          }
+        },
+        "name": "cdr-color-border-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tooltip.default}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The default icon color"
+        },
+        "filePath": "tokens/themes/docsite/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The default icon color"
+          }
+        },
+        "name": "cdr-color-icon-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.default}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "Emphasis or darkest icon color on a light background"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "Emphasis or darkest icon color on a light background"
+          }
+        },
+        "name": "cdr-color-icon-emphasis",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.emphasis}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The icon link color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The icon link color"
+          }
+        },
+        "name": "cdr-color-icon-link",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.link}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The disabled icon color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The disabled icon color"
+          }
+        },
+        "name": "cdr-color-icon-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.disabled}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Rest state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Rest state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected-active}"
+      },
+      {
+        "$value": "#726d64",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The default message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The default message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.default}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The success message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The success message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The warning message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The warning message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The error message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The error message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.error}"
+      },
+      {
+        "$value": "#408e86",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The informational message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The informational message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.info}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected on hover"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected on focus"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-focus}"
+      }
+    ],
+    "color": [
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "chip-default-selected-active",
+          "description": {
+            "what": "Active background for selected chips",
+            "when": "Use when a chip is selected and active"
+          }
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "chip-default-selected-active",
+            "description": {
+              "what": "Active background for selected chips",
+              "when": "Use when a chip is selected and active"
+            }
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-active}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "slide-default",
+          "description": {
+            "what": "Default slide background color",
+            "when": "Use for the resting state of slide surfaces."
+          }
+        },
+        "filePath": "tokens/global/slide.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "slide-default",
+            "description": {
+              "what": "Default slide background color",
+              "when": "Use for the resting state of slide surfaces."
+            }
+          }
+        },
+        "name": "cdr-color-background-slide-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.slide.hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "slide-hover",
+          "description": {
+            "what": "Hover background color for slide surfaces",
+            "when": "Use when a slide component is hovered",
+            "alternatives": [
+              "#fafbf9"
+            ]
+          }
+        },
+        "filePath": "tokens/global/slide.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "slide-hover",
+            "description": {
+              "what": "Hover background color for slide surfaces",
+              "when": "Use when a slide component is hovered",
+              "alternatives": [
+                "{color.background.slide.default}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-color-background-slide-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.slide.default}"
+      }
+    ],
+    "form": [
+      {
+        "$value": "4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "height",
+          "category": "form",
+          "example": "height-default",
+          "description": {
+            "what": "Default input height",
+            "when": "Use for standard form fields",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "docs": {
+            "type": "height",
+            "category": "form",
+            "example": "height-default",
+            "description": {
+              "what": "Default input height",
+              "when": "Use for standard form fields",
+              "alternatives": [
+                "{form.input.height-large}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-input-height-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.input.height-default}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "height",
+          "category": "form",
+          "example": "height-large",
+          "description": {
+            "what": "Large input height",
+            "when": "Use for spacious layouts"
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "48px",
+          "$type": "dimension",
+          "docs": {
+            "type": "height",
+            "category": "form",
+            "example": "height-large",
+            "description": {
+              "what": "Large input height",
+              "when": "Use for spacious layouts"
+            }
+          }
+        },
+        "name": "cdr-form-input-height-large",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.input.height-large}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-small",
+          "description": {
+            "what": "Small figure size",
+            "when": "Use for compact forms",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-small",
+            "description": {
+              "what": "Small figure size",
+              "when": "Use for compact forms",
+              "alternatives": [
+                "{form.figure.size-medium}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-small",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-small}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-medium",
+          "description": {
+            "what": "Medium figure size",
+            "when": "Use for standard forms",
+            "alternatives": [
+              "2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-medium",
+            "description": {
+              "what": "Medium figure size",
+              "when": "Use for standard forms",
+              "alternatives": [
+                "{form.figure.size-large}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-medium",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-medium}"
+      },
+      {
+        "$value": "2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-large",
+          "description": {
+            "what": "Large figure size",
+            "when": "Use for large or expressive forms"
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-large",
+            "description": {
+              "what": "Large figure size",
+              "when": "Use for large or expressive forms"
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-large",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-large}"
+      }
+    ],
+    "icon": [
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size-sm",
+          "description": {
+            "what": "Small icon size",
+            "when": "Use for dense UI",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size-sm",
+            "description": {
+              "what": "Small icon size",
+              "when": "Use for dense UI",
+              "alternatives": [
+                "{icon.size}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-icon-size-sm",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size-sm}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size",
+          "description": {
+            "what": "Default icon size",
+            "when": "Use for standard UI",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size",
+            "description": {
+              "what": "Default icon size",
+              "when": "Use for standard UI",
+              "alternatives": [
+                "{icon.size-lg}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-icon-size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size-lg",
+          "description": {
+            "what": "Large icon size",
+            "when": "Use for prominent UI elements"
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size-lg",
+            "description": {
+              "what": "Large icon size",
+              "when": "Use for prominent UI elements"
+            }
+          }
+        },
+        "name": "cdr-icon-size-lg",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size-lg}"
+      }
+    ],
+    "motion": [
+      {
+        "$value": "0.10s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-1-x",
+          "description": {
+            "what": "Very short animation duration",
+            "when": "Use for micro-interactions",
+            "alternatives": [
+              "0.20s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "100ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-1-x",
+            "description": {
+              "what": "Very short animation duration",
+              "when": "Use for micro-interactions",
+              "alternatives": [
+                "{duration.2-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-1-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.1-x}"
+      },
+      {
+        "$value": "0.20s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-2-x",
+          "description": {
+            "what": "Short animation duration",
+            "when": "Use for quick UI transitions",
+            "alternatives": [
+              "0.30s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "200ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-2-x",
+            "description": {
+              "what": "Short animation duration",
+              "when": "Use for quick UI transitions",
+              "alternatives": [
+                "{duration.3-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-2-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.2-x}"
+      },
+      {
+        "$value": "0.30s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-3-x",
+          "description": {
+            "what": "Medium duration",
+            "when": "Use for standard UI animations",
+            "alternatives": [
+              "0.40s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "300ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-3-x",
+            "description": {
+              "what": "Medium duration",
+              "when": "Use for standard UI animations",
+              "alternatives": [
+                "{duration.4-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-3-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.3-x}"
+      },
+      {
+        "$value": "0.40s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-4-x",
+          "description": {
+            "what": "Long duration",
+            "when": "Use for slower transitions",
+            "alternatives": [
+              "0.50s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "400ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-4-x",
+            "description": {
+              "what": "Long duration",
+              "when": "Use for slower transitions",
+              "alternatives": [
+                "{duration.5-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-4-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.4-x}"
+      },
+      {
+        "$value": "0.50s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-5-x",
+          "description": {
+            "what": "Very long duration",
+            "when": "Use for dramatic or modal transitions",
+            "alternatives": [
+              "0.60s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "500ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-5-x",
+            "description": {
+              "what": "Very long duration",
+              "when": "Use for dramatic or modal transitions",
+              "alternatives": [
+                "{duration.6-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-5-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.5-x}"
+      },
+      {
+        "$value": "0.60s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-6-x",
+          "description": {
+            "what": "Extra long duration",
+            "when": "Use sparingly for large UI shifts"
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "600ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-6-x",
+            "description": {
+              "what": "Extra long duration",
+              "when": "Use sparingly for large UI shifts"
+            }
+          }
+        },
+        "name": "cdr-duration-6-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.6-x}"
+      },
+      {
+        "$value": "cubic-bezier(0.32, 0.94, 0.60, 1)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "ease-out",
+          "description": {
+            "what": "Ease-out timing curve",
+            "when": "Use when animations should decelerate smoothly",
+            "alternatives": [
+              "cubic-bezier(0.15, 0, 0.15, 0)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0.32, 0.94, 0.60, 1)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "ease-out",
+            "description": {
+              "what": "Ease-out timing curve",
+              "when": "Use when animations should decelerate smoothly",
+              "alternatives": [
+                "{timing.function-ease}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-timing-function-ease-out",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-ease-out}"
+      },
+      {
+        "$value": "cubic-bezier(0.15, 0, 0.15, 0)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "ease",
+          "description": {
+            "what": "Ease timing curve",
+            "when": "Use for general-purpose animations",
+            "alternatives": [
+              "cubic-bezier(0, 0, 1, 1)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0.15, 0, 0.15, 0)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "ease",
+            "description": {
+              "what": "Ease timing curve",
+              "when": "Use for general-purpose animations",
+              "alternatives": [
+                "{timing.function-linear}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-timing-function-ease",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-ease}"
+      },
+      {
+        "$value": "cubic-bezier(0, 0, 1, 1)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "linear",
+          "description": {
+            "what": "Linear timing curve",
+            "when": "Use for constant-speed animations"
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0, 0, 1, 1)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "linear",
+            "description": {
+              "what": "Linear timing curve",
+              "when": "Use for constant-speed animations"
+            }
+          }
+        },
+        "name": "cdr-timing-function-linear",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-linear}"
+      }
+    ],
+    "prominence": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-x",
+          "description": {
+            "what": "X for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-x",
+            "description": {
+              "what": "X for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-x}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-y",
+          "description": {
+            "what": "Y for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-y",
+            "description": {
+              "what": "Y for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-y}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-blur",
+          "description": {
+            "what": "Blur for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-blur",
+            "description": {
+              "what": "Blur for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-spread",
+          "description": {
+            "what": "Spread for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-spread",
+            "description": {
+              "what": "Spread for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-color",
+          "description": {
+            "what": "Color for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-color",
+            "description": {
+              "what": "Color for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-x",
+          "description": {
+            "what": "X for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-x",
+            "description": {
+              "what": "X for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-y",
+          "description": {
+            "what": "Y for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-y",
+            "description": {
+              "what": "Y for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-y}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-blur",
+          "description": {
+            "what": "Blur for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-blur",
+            "description": {
+              "what": "Blur for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-spread",
+          "description": {
+            "what": "Spread for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-spread",
+            "description": {
+              "what": "Spread for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-color",
+          "description": {
+            "what": "Color for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-color",
+            "description": {
+              "what": "Color for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-x",
+          "description": {
+            "what": "X for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-x",
+            "description": {
+              "what": "X for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-y",
+          "description": {
+            "what": "Y for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-y",
+            "description": {
+              "what": "Y for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-y}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-blur",
+          "description": {
+            "what": "Blur for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-blur",
+            "description": {
+              "what": "Blur for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-spread",
+          "description": {
+            "what": "Spread for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-spread",
+            "description": {
+              "what": "Spread for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-color",
+          "description": {
+            "what": "Color for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-color",
+            "description": {
+              "what": "Color for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-x",
+          "description": {
+            "what": "X for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-x",
+            "description": {
+              "what": "X for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-y",
+          "description": {
+            "what": "Y for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "8px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-y",
+            "description": {
+              "what": "Y for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-y}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-blur",
+          "description": {
+            "what": "Blur for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "8px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-blur",
+            "description": {
+              "what": "Blur for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-spread",
+          "description": {
+            "what": "Spread for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-spread",
+            "description": {
+              "what": "Spread for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-color",
+          "description": {
+            "what": "Color for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-color",
+            "description": {
+              "what": "Color for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-x",
+          "description": {
+            "what": "X for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-x",
+            "description": {
+              "what": "X for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-y",
+          "description": {
+            "what": "Y for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-y",
+            "description": {
+              "what": "Y for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-y}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-blur",
+          "description": {
+            "what": "Blur for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-blur",
+            "description": {
+              "what": "Blur for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-spread",
+          "description": {
+            "what": "Spread for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-spread",
+            "description": {
+              "what": "Spread for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-color",
+          "description": {
+            "what": "Color for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-color",
+            "description": {
+              "what": "Color for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-color}"
+      }
+    ],
+    "radius": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "sharp",
+          "description": {
+            "what": "Zero-radius corner",
+            "when": "Use for crisp, squared edges",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "sharp",
+            "description": {
+              "what": "Zero-radius corner",
+              "when": "Use for crisp, squared edges",
+              "alternatives": [
+                "{radius.soft}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-sharp",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.sharp}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "soft",
+          "description": {
+            "what": "Small, subtle corner radius",
+            "when": "Use for gentle rounding",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "soft",
+            "description": {
+              "what": "Small, subtle corner radius",
+              "when": "Use for gentle rounding",
+              "alternatives": [
+                "{radius.softer}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-soft",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.soft}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "softer",
+          "description": {
+            "what": "Medium corner radius",
+            "when": "Use for more noticeable rounding",
+            "alternatives": [
+              "0.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "softer",
+            "description": {
+              "what": "Medium corner radius",
+              "when": "Use for more noticeable rounding",
+              "alternatives": [
+                "{radius.softest}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-softer",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.softer}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "softest",
+          "description": {
+            "what": "Large rounded corner",
+            "when": "Use for pill-like shapes",
+            "alternatives": [
+              "0.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "6px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "softest",
+            "description": {
+              "what": "Large rounded corner",
+              "when": "Use for pill-like shapes",
+              "alternatives": [
+                "{radius.softest}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-softest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.softest}"
+      },
+      {
+        "$value": "999.9rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "round",
+          "description": {
+            "what": "Fully circular radius",
+            "when": "Use for circular elements"
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "9999px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "round",
+            "description": {
+              "what": "Fully circular radius",
+              "when": "Use for circular elements"
+            }
+          }
+        },
+        "name": "cdr-radius-round",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.round}"
+      }
+    ],
+    "spacing": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Zero spacing, removes all space between elements.",
+            "when": "Use when elements must be flush against each other with no gap."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.zero}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Zero spacing, removes all space between elements.",
+              "when": "Use when elements must be flush against each other with no gap."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-zero",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.zero}"
+      },
+      {
+        "$value": "0.1rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "The smallest static spacing unit, one-sixteenth of the base.",
+            "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "The smallest static spacing unit, one-sixteenth of the base.",
+              "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.sixteenth-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-eighth of the base unit.",
+            "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-eighth of the base unit.",
+              "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.eighth-x}"
+      },
+      {
+        "$value": "0.3rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-sixteenths of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-sixteenths of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-sixteenth-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-quarter of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-quarter of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.quarter-x}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-eighths of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-eighths of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.1}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-eighth-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-half of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.4rem, 0.4rem + 0.11cqi, 0.5rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-half of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.2}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.half-x}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-quarters of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-quarters of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.3}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-quarter-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "The base static spacing unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "The base static spacing unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.3}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-one-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.one-x}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one and a half times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one and a half times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.4}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-one-and-a-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.one-and-a-half-x}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at two times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at two times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.5}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-two-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.two-x}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(2.4rem, 2.2rem + 0.66cqi, 3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "48px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.6}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-x}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at four times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(3.2rem, 2.9rem + 0.88cqi, 4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "64px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at four times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.7}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-four-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.four-x}"
+      },
+      {
+        "$value": "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "The smallest fluid spacing step, scaling from 3.2px to 4.8px.",
+            "when": "Use for the tightest gaps between inline elements such as an icon and a label."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.2rem + 0.11cqi",
+            "max": "0.3rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "The smallest fluid spacing step, scaling from 3.2px to 4.8px.",
+              "when": "Use for the tightest gaps between inline elements such as an icon and a label."
+            }
+          }
+        },
+        "name": "cdr-space-scale-0",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0}"
+      },
+      {
+        "$value": "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 1, scaling from 4.8px to 6.4px.",
+            "when": "Use for minimal separation between closely related elements."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.3rem",
+            "ideal": "0.3rem + 0.11cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 1, scaling from 4.8px to 6.4px.",
+              "when": "Use for minimal separation between closely related elements."
+            }
+          }
+        },
+        "name": "cdr-space-scale-1",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.1}"
+      },
+      {
+        "$value": "clamp(0.4rem, 0.4rem + 0.11cqi, 0.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 2, scaling from 6.4px to 8px.",
+            "when": "Use for small gaps such as between stacked text elements or tight component internals."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.4rem + 0.11cqi",
+            "max": "0.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 2, scaling from 6.4px to 8px.",
+              "when": "Use for small gaps such as between stacked text elements or tight component internals."
+            }
+          }
+        },
+        "name": "cdr-space-scale-2",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.2}"
+      },
+      {
+        "$value": "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 3, scaling from 12.8px to 16px. Equivalent to the static base unit.",
+            "when": "Use for spacing between related components such as form fields or list items."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.7rem + 0.22cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 3, scaling from 12.8px to 16px. Equivalent to the static base unit.",
+              "when": "Use for spacing between related components such as form fields or list items."
+            }
+          }
+        },
+        "name": "cdr-space-scale-3",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3}"
+      },
+      {
+        "$value": "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 4, scaling from 19.2px to 24px.",
+            "when": "Use for spacing between distinct components or content groups."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.2rem",
+            "ideal": "1.1rem + 0.33cqi",
+            "max": "1.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 4, scaling from 19.2px to 24px.",
+              "when": "Use for spacing between distinct components or content groups."
+            }
+          }
+        },
+        "name": "cdr-space-scale-4",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.4}"
+      },
+      {
+        "$value": "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 5, scaling from 25.6px to 32px.",
+            "when": "Use for separation between major content sections."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.6rem",
+            "ideal": "1.5rem + 0.44cqi",
+            "max": "2rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 5, scaling from 25.6px to 32px.",
+              "when": "Use for separation between major content sections."
+            }
+          }
+        },
+        "name": "cdr-space-scale-5",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.5}"
+      },
+      {
+        "$value": "clamp(2.4rem, 2.2rem + 0.66cqi, 3rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 6, scaling from 38.4px to 48px.",
+            "when": "Use for generous separation between page-level sections."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.4rem",
+            "ideal": "2.2rem + 0.66cqi",
+            "max": "3rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 6, scaling from 38.4px to 48px.",
+              "when": "Use for generous separation between page-level sections."
+            }
+          }
+        },
+        "name": "cdr-space-scale-6",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.6}"
+      },
+      {
+        "$value": "clamp(3.2rem, 2.9rem + 0.88cqi, 4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 7, scaling from 51.2px to 64px.",
+            "when": "Use for large layout gaps such as between hero sections and page content."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.2rem",
+            "ideal": "2.9rem + 0.88cqi",
+            "max": "4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 7, scaling from 51.2px to 64px.",
+              "when": "Use for large layout gaps such as between hero sections and page content."
+            }
+          }
+        },
+        "name": "cdr-space-scale-7",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.7}"
+      },
+      {
+        "$value": "clamp(4.8rem, 4.4rem + 1.31cqi, 6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "The largest fluid spacing step, scaling from 76.8px to 96px.",
+            "when": "Use for major page-level separation such as between full-width content blocks."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "4.8rem",
+            "ideal": "4.4rem + 1.31cqi",
+            "max": "6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "The largest fluid spacing step, scaling from 76.8px to 96px.",
+              "when": "Use for major page-level separation such as between full-width content blocks."
+            }
+          }
+        },
+        "name": "cdr-space-scale-8",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.8}"
+      },
+      {
+        "$value": "clamp(0.2rem, 0.1rem + 0.223cqi, 0.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+            "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.1rem + 0.223cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+              "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-0-1",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0--1}"
+      },
+      {
+        "$value": "clamp(0.4rem, 0.2rem + 0.66cqi, 1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+            "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.2rem + 0.66cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+              "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-3-4",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--4}"
+      },
+      {
+        "$value": "clamp(0.8rem, 0.1404px + 1.21cqi, 1.6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+            "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)",
+              "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.1404px + 1.21cqi",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+              "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}",
+                "{space.scale.5}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-3-5",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--5}"
+      },
+      {
+        "$value": "0.1rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-sixteenth of the base unit.",
+            "when": "Use for the tightest padding on very small components such as micro badges."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-sixteenth of the base unit.",
+              "when": "Use for the tightest padding on very small components such as micro badges."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.sixteenth-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-eighth of the base unit.",
+            "when": "Use for compact components such as badges or tags."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-eighth of the base unit.",
+              "when": "Use for compact components such as badges or tags."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished eighth-x inset, compressed to zero.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished eighth-x inset, compressed to zero.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished eighth-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished eighth-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish-left-right}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched eighth-x inset, expanded beyond the base.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched eighth-x inset, expanded beyond the base.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched eighth-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched eighth-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch-left-right}"
+      },
+      {
+        "$value": "0.3rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-sixteenths of the base unit.",
+            "when": "Use for compact components needing slightly more padding than eighth-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-sixteenths of the base unit.",
+              "when": "Use for compact components needing slightly more padding than eighth-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-sixteenth-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-quarter of the base unit.",
+            "when": "Use for small components such as chips or compact buttons."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-quarter of the base unit.",
+              "when": "Use for small components such as chips or compact buttons."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "spacingModifier": 0.5,
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished quarter-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "spacingModifier": "{options.space.squish}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished quarter-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish-left-right}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched quarter-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched quarter-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch-left-right}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-eighths of the base unit.",
+            "when": "Use for components needing slightly more padding than quarter-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-eighths of the base unit.",
+              "when": "Use for components needing slightly more padding than quarter-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-eighth-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-half of the base unit.",
+            "when": "Use for medium-density components such as form inputs or standard buttons."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-half of the base unit.",
+              "when": "Use for medium-density components such as form inputs or standard buttons."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished half-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished half-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish-left-right}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched half-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched half-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch-left-right}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-quarters of the base unit.",
+            "when": "Use for components needing slightly more padding than half-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-quarters of the base unit.",
+              "when": "Use for components needing slightly more padding than half-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished three-quarter-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished three-quarter-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish-top-bottom}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished three-quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished three-quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish-left-right}"
+      },
+      {
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched three-quarter-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched three-quarter-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched three-quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched three-quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch-left-right}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at the base unit.",
+            "when": "Use for standard component padding such as cards or panels."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at the base unit.",
+              "when": "Use for standard component padding such as cards or panels."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished one-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished one-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish-top-bottom}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished one-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished one-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish-left-right}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched one-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched one-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched one-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched one-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch-left-right}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one and a half times the base unit.",
+            "when": "Use for components needing generous padding such as modals or large cards."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one and a half times the base unit.",
+              "when": "Use for components needing generous padding such as modals or large cards."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished one-and-a-half-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished one-and-a-half-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish-top-bottom}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished one-and-a-half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished one-and-a-half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish-left-right}"
+      },
+      {
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched one-and-a-half-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched one-and-a-half-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched one-and-a-half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched one-and-a-half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch-left-right}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at two times the base unit.",
+            "when": "Use for spacious layouts such as page sections or large containers."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at two times the base unit.",
+              "when": "Use for spacious layouts such as page sections or large containers."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished two-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished two-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish-top-bottom}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished two-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished two-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish-left-right}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched two-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched two-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched two-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched two-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch-left-right}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three times the base unit.",
+            "when": "Use for very spacious layouts or full-width content areas."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three times the base unit.",
+              "when": "Use for very spacious layouts or full-width content areas."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished three-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished three-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish-top-bottom}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished three-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished three-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish-left-right}"
+      },
+      {
+        "$value": "7.2rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched three-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched three-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched three-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched three-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch-left-right}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at four times the base unit.",
+            "when": "Use for the most spacious layouts such as hero sections."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at four times the base unit.",
+              "when": "Use for the most spacious layouts such as hero sections."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished four-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished four-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish-top-bottom}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished four-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished four-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish-left-right}"
+      },
+      {
+        "$value": "9.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched four-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched four-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched four-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "64px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched four-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch-left-right}"
+      }
+    ]
+  },
+  "web": {
+    "display": [
+      {
+        "$value": "Mixin for screen readers only",
+        "category": "display",
+        "name": "cdr-display-sr-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      },
+      {
+        "$value": "Mixin for screen readers only, but remains focusable",
+        "category": "display",
+        "name": "cdr-display-sr-only-focusable",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      }
+    ],
+    "container": [
+      {
+        "$value": "Mixin for wrapping page content",
+        "category": "container",
+        "name": "cdr-container",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      },
+      {
+        "$value": "Mixin for wrapping page content responsively",
+        "category": "container",
+        "name": "cdr-container-fluid",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      }
+    ],
+    "media-query": [
+      {
+        "$value": "Mixin content rendered at extra small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-xs-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at extra small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-xs-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-sm-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-sm-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below small breakpoint",
+        "category": "media-query",
+        "name": "cdr-sm-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at medium breakpoint only",
+        "category": "media-query",
+        "name": "cdr-md-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at medium breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-md-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below medium breakpoint",
+        "category": "media-query",
+        "name": "cdr-md-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at large breakpoint only",
+        "category": "media-query",
+        "name": "cdr-lg-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at large breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-lg-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below large breakpoint",
+        "category": "media-query",
+        "name": "cdr-lg-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      }
+    ],
+    "container-query": [
+      {
+        "$value": "Container content rendered at extra small breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-xs-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at extra small breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-xs-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at small breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at small breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below small breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at medium breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at medium breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below medium breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at large breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at large breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below large breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      }
+    ],
+    "misc": [
+      {
+        "$value": "Stuart",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.serif-main}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-serif-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "serif-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.serif-brand-font}"
+      },
+      {
+        "$value": "Stuart, \"Stuart fallback\", Georgia, serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-serif",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "serif",
+          "deprecated": false
+        },
+        "key": "{font.family.serif}"
+      },
+      {
+        "$value": "Graphik",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.sans-main}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-sans-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "sans-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.sans-brand-font}"
+      },
+      {
+        "$value": "Graphik, \"Graphik fallback\", \"Helvetica Neue\", sans-serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-sans",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "sans",
+          "deprecated": false
+        },
+        "key": "{font.family.sans}"
+      },
+      {
+        "$value": "Pressura,  \"Avenir Next\", Roboto, sans-serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.mono-rounded}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-mono-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "mono-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.mono-brand-font}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-default-family",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-default.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-default-style",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-default.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-default-weight",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-default.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-default-letter-spacing",
+        "attributes": {
+          "category": "text-default",
+          "type": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-default.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-default-size",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-default.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-default-line-height",
+        "attributes": {
+          "category": "text-default",
+          "type": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-default.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-eyebrow-100-family",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-eyebrow-100-style",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-eyebrow-100-weight",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looser}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-eyebrow-100-letter-spacing",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-eyebrow-100-size",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-eyebrow-100-line-height",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "uppercase",
+        "$type": "textTransform",
+        "original": {
+          "$value": "uppercase",
+          "$type": "textTransform"
+        },
+        "name": "cdr-text-eyebrow-100-transform",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "textTransform",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.textTransform}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-300-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-300-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-300-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looseish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-300-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-300-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-300-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-400-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-400-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-400-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-400-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-400-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-400-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-500-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-500-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-500-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-500-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-500-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-500-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-300-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-300-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-300-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looseish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-300-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-300-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-400-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-400-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-400-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-400-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-400-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-500-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-500-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-500-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-500-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-500-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-200-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-200-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-200-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-200-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-200-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-300-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-300-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-300-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-300-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-300-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-400-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-400-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-400-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-400-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-400-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-500-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-500-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-500-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-500-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-500-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-600-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-600-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-600-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-600-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-600-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-200-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-200-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-200-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-200-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-200-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-300-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-300-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-300-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-300-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-300-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-400-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-400-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-400-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-400-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-400-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-500-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-500-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-500-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-500-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-500-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-600-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-600-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-600-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-600-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-600-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-700-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-700-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-700-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-700-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-700-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "32",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.900}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-700-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-800-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-800-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-800-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-800-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-800-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-900-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-900-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-900-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-900-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "44",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-900-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1000-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1000-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1000-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1000-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "50",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1000-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1100-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1100-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1100-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1100-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "56",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1100-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1200-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1200-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1200-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1200-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1200-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-600-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-600-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-600-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-600-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-600-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-700-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-700-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-700-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-700-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "32",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.900}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-700-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-800-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-800-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-800-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-800-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-800-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-900-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-900-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-900-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-900-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "44",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-900-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "50",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "56",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-800-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-800-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-800-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-800-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-800-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-900-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-900-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-900-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-900-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-900-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1000-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1000-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1000-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1000-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "48",
+        "$type": "number",
+        "original": {
+          "$value": "48px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1000-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1100-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1100-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1100-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1100-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "52",
+        "$type": "number",
+        "original": {
+          "$value": "52px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1100-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1200-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1200-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1200-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1200-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "60",
+        "$type": "number",
+        "original": {
+          "$value": "60px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1200-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1300-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1300-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1300-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1300-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1300-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1400-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1400-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1400-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "6.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1400-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "72",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1400-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1500-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1500-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1500-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "7.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1500-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "80",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1700}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1500-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1600-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1600-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1600-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "8.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1600-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "92",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1600-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-300-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-300-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-300-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-300-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-300-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-400-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-400-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-400-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-400-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-400-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-500-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-500-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-500-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-500-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-500-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-600-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-600-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-600-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-600-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-600-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-100-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-100-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-100-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-100-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-100-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "16",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-100-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-200-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-200-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-200-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-200-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-200-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-300-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-300-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-300-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-300-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-300-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-400-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-400-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-400-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-400-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-400-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-500-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-500-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-500-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-500-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-500-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-600-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-600-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-600-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-600-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-600-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-700-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-700-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-700-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-700-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-700-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-800-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-800-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-800-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.064rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightest}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-800-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-800-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-100-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-100-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-100-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-100-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-100-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "16",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-100-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-200-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-200-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-200-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-200-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-200-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-300-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-300-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-300-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-300-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-300-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-400-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-400-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-400-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-400-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-400-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-500-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-500-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-500-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-500-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-500-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-600-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-600-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-600-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-600-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-600-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-700-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-700-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-700-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-700-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-700-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-800-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-800-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-800-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-800-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-800-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-200-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-200-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-200-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-200-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-200-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-300-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-300-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-300-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-300-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-300-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-400-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-400-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-400-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-400-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-400-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-500-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-500-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-500-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-500-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-500-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-600-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-600-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-600-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-600-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-600-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-700-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-700-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-700-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-700-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-700-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-800-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-800-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-800-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-800-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-800-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-200-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-200-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-200-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-200-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-200-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-300-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-300-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-300-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-300-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-300-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-400-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-400-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-400-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-400-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-400-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-500-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-500-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-500-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-500-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-500-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-600-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-600-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-600-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-600-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-600-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-700-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-700-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-700-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-700-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-700-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-800-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-800-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-800-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-800-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-800-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.lineHeight}"
+      }
+    ],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [
+      {
+        "$value": "0 0 0 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.flat-x.$value} {prominence.flat-y.$value} {prominence.flat-blur.$value} {prominence.flat-spread.$value} {prominence.flat-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-flat",
+        "attributes": {
+          "category": "prominence",
+          "type": "flat",
+          "deprecated": false
+        },
+        "key": "{prominence.flat}"
+      },
+      {
+        "$value": "0 0.2rem 0.2rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.raised-x.$value} {prominence.raised-y.$value} {prominence.raised-blur.$value} {prominence.raised-spread.$value} {prominence.raised-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-raised",
+        "attributes": {
+          "category": "prominence",
+          "type": "raised",
+          "deprecated": false
+        },
+        "key": "{prominence.raised}"
+      },
+      {
+        "$value": "0 0.4rem 0.4rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.elevated-x.$value} {prominence.elevated-y.$value} {prominence.elevated-blur.$value} {prominence.elevated-spread.$value} {prominence.elevated-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-elevated",
+        "attributes": {
+          "category": "prominence",
+          "type": "elevated",
+          "deprecated": false
+        },
+        "key": "{prominence.elevated}"
+      },
+      {
+        "$value": "0 0.8rem 0.8rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.floating-x.$value} {prominence.floating-y.$value} {prominence.floating-blur.$value} {prominence.floating-spread.$value} {prominence.floating-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-floating",
+        "attributes": {
+          "category": "prominence",
+          "type": "floating",
+          "deprecated": false
+        },
+        "key": "{prominence.floating}"
+      },
+      {
+        "$value": "0 1.6rem 1.6rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.lifted-x.$value} {prominence.lifted-y.$value} {prominence.lifted-blur.$value} {prominence.lifted-spread.$value} {prominence.lifted-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-lifted",
+        "attributes": {
+          "category": "prominence",
+          "type": "lifted",
+          "deprecated": false
+        },
+        "key": "{prominence.lifted}"
+      }
+    ],
+    "radius": [],
+    "spacing": [
+      {
+        "$value": "0 0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.eighth-x-squish-top-bottom.$value} {space.inset.eighth-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "eighth-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish}"
+      },
+      {
+        "$value": "0.4rem 0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.eighth-x-stretch-top-bottom.$value} {space.inset.eighth-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "eighth-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch}"
+      },
+      {
+        "$value": "0.2rem 0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.quarter-x-squish-top-bottom.$value} {space.inset.quarter-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "quarter-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish}"
+      },
+      {
+        "$value": "0.6rem 0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.quarter-x-stretch-top-bottom.$value} {space.inset.quarter-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "quarter-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch}"
+      },
+      {
+        "$value": "0.4rem 0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.half-x-squish-top-bottom.$value} {space.inset.half-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "half-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish}"
+      },
+      {
+        "$value": "1.2rem 0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.half-x-stretch-top-bottom.$value} {space.inset.half-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "half-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch}"
+      },
+      {
+        "$value": "0.6rem 1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-quarter-x-squish-top-bottom.$value} {space.inset.three-quarter-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-quarter-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish}"
+      },
+      {
+        "$value": "1.8rem 1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-quarter-x-stretch-top-bottom.$value} {space.inset.three-quarter-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-quarter-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch}"
+      },
+      {
+        "$value": "0.8rem 1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-x-squish-top-bottom.$value} {space.inset.one-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish}"
+      },
+      {
+        "$value": "2.4rem 1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-x-stretch-top-bottom.$value} {space.inset.one-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch}"
+      },
+      {
+        "$value": "1.2rem 2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-and-a-half-x-squish-top-bottom.$value} {space.inset.one-and-a-half-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-and-a-half-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish}"
+      },
+      {
+        "$value": "3.6rem 2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-and-a-half-x-stretch-top-bottom.$value} {space.inset.one-and-a-half-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-and-a-half-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch}"
+      },
+      {
+        "$value": "1.6rem 3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.two-x-squish-top-bottom.$value} {space.inset.two-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "two-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish}"
+      },
+      {
+        "$value": "4.8rem 3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.two-x-stretch-top-bottom.$value} {space.inset.two-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "two-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch}"
+      },
+      {
+        "$value": "2.4rem 4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-x-squish-top-bottom.$value} {space.inset.three-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish}"
+      },
+      {
+        "$value": "7.2rem 4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-x-stretch-top-bottom.$value} {space.inset.three-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch}"
+      },
+      {
+        "$value": "3.2rem 6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.four-x-squish-top-bottom.$value} {space.inset.four-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "four-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish}"
+      },
+      {
+        "$value": "9.6rem 6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.four-x-stretch-top-bottom.$value} {space.inset.four-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "four-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch}"
+      }
+    ],
+    "breakpoints": [
+      {
+        "$value": "0",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-xs",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "xs",
+          "deprecated": false
+        },
+        "key": "{breakpoint.xs}"
+      },
+      {
+        "$value": "768px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "768px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-sm",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "sm",
+          "deprecated": false
+        },
+        "key": "{breakpoint.sm}"
+      },
+      {
+        "$value": "992px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "992px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-md",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "md",
+          "deprecated": false
+        },
+        "key": "{breakpoint.md}"
+      },
+      {
+        "$value": "1232px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "1232px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-lg",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "lg",
+          "deprecated": false
+        },
+        "key": "{breakpoint.lg}"
+      }
+    ],
+    "text": [
+      {
+        "$value": "clamp(2.8rem, 0.55vw + 2.62rem, 3.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.8rem, 0.55vw + 2.62rem, 3.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.1}"
+      },
+      {
+        "$value": "clamp(3.15rem, 0.89vw + 2.87rem, 3.96rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.15rem, 0.89vw + 2.87rem, 3.96rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.2}"
+      },
+      {
+        "$value": "clamp(3.54rem, 1.32vw + 3.12rem, 4.75rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.54rem, 1.32vw + 3.12rem, 4.75rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.3}"
+      },
+      {
+        "$value": "clamp(3.99rem, 1.88vw + 3.38rem, 5.7rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.99rem, 1.88vw + 3.38rem, 5.7rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-4",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "4",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.4}"
+      },
+      {
+        "$value": "clamp(4.49rem, 2.59vw + 3.66rem, 6.84rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(4.49rem, 2.59vw + 3.66rem, 6.84rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-5",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "5",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.5}"
+      },
+      {
+        "$value": "clamp(2.8rem, 0.77vw + 2.55rem, 3.5rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.8rem, 0.77vw + 2.55rem, 3.5rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.2}"
+      },
+      {
+        "$value": "clamp(3.3rem, 1.1vw + 2.95rem, 4.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.3rem, 1.1vw + 2.95rem, 4.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.3}"
+      },
+      {
+        "$value": "clamp(3.9rem, 1.53vw + 3.41rem, 5.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.9rem, 1.53vw + 3.41rem, 5.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-4",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "4",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.4}"
+      },
+      {
+        "$value": "clamp(4.6rem, 2.1vw + 3.93rem, 6.51rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(4.6rem, 2.1vw + 3.93rem, 6.51rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-5",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "5",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.5}"
+      },
+      {
+        "$value": "clamp(5.43rem, 2.83vw + 4.52rem, 8.01rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(5.43rem, 2.83vw + 4.52rem, 8.01rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-6",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "6",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.6}"
+      },
+      {
+        "$value": "clamp(6.41rem, 3.78vw + 5.2rem, 9.85rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(6.41rem, 3.78vw + 5.2rem, 9.85rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-7",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "7",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.7}"
+      },
+      {
+        "$value": "clamp(2.2rem, 0.44vw + 2.06rem, 2.6rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.2rem, 0.44vw + 2.06rem, 2.6rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.0}"
+      },
+      {
+        "$value": "clamp(2.57rem, 0.6vw + 2.38rem, 3.12rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.57rem, 0.6vw + 2.38rem, 3.12rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.1}"
+      },
+      {
+        "$value": "clamp(3.01rem, 0.8vw + 2.75rem, 3.74rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.01rem, 0.8vw + 2.75rem, 3.74rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.2}"
+      },
+      {
+        "$value": "clamp(3rem, 0.44vw + 2.86rem, 3.4rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3rem, 0.44vw + 2.86rem, 3.4rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-body-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "body",
+          "subitem": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.body.0}"
+      },
+      {
+        "$value": "clamp(3.4rem, 0.55vw + 3.23rem, 3.91rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.4rem, 0.55vw + 3.23rem, 3.91rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-body-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "body",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.body.1}"
+      },
+      {
+        "$value": "clamp(2.2rem, 0.4386vw + 2.05965rem, 2.6rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.2rem, 0.4386vw + 2.05965rem, 2.6rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.0}"
+      },
+      {
+        "$value": "clamp(2.552rem, 0.62281vw + 2.3527rem, 3.12rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.552rem, 0.62281vw + 2.3527rem, 3.12rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.1}"
+      },
+      {
+        "$value": "clamp(2.96032rem, 0.8593vw + 2.68534rem, 3.744rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.96032rem, 0.8593vw + 2.68534rem, 3.744rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.2}"
+      },
+      {
+        "$value": "clamp(3.43397rem, 1.161vw + 3.06245rem, 4.4928rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.43397rem, 1.161vw + 3.06245rem, 4.4928rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.3}"
+      },
+      {
+        "$value": "clamp(1.89655rem, 0.29618vw + 1.80177rem, 2.16667rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(1.89655rem, 0.29618vw + 1.80177rem, 2.16667rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-minus-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "minus-1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.minus-1}"
+      },
+      {
+        "$value": "clamp(1.6rem, 0.44cqw + 1.46rem, 2rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.6rem",
+            "ideal": "0.44cqw + 1.46rem",
+            "max": "2rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-0",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "0",
+          "deprecated": false
+        },
+        "key": "{type.scale.0}"
+      },
+      {
+        "$value": "clamp(1.92rem, 0.64cqw + 1.72rem, 2.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.92rem",
+            "ideal": "0.64cqw + 1.72rem",
+            "max": "2.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-1",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "1",
+          "deprecated": false
+        },
+        "key": "{type.scale.1}"
+      },
+      {
+        "$value": "clamp(2.3rem, 0.9cqw + 2.02rem, 3.13rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.3rem",
+            "ideal": "0.9cqw + 2.02rem",
+            "max": "3.13rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-2",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "2",
+          "deprecated": false
+        },
+        "key": "{type.scale.2}"
+      },
+      {
+        "$value": "clamp(2.76rem, 1.25cqw + 2.36rem, 3.91rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.76rem",
+            "ideal": "1.25cqw + 2.36rem",
+            "max": "3.91rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-3",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "3",
+          "deprecated": false
+        },
+        "key": "{type.scale.3}"
+      },
+      {
+        "$value": "clamp(3.32rem, 1.72cqw + 2.77rem, 4.88rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.32rem",
+            "ideal": "1.72cqw + 2.77rem",
+            "max": "4.88rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-4",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "4",
+          "deprecated": false
+        },
+        "key": "{type.scale.4}"
+      },
+      {
+        "$value": "clamp(3.98rem, 2.33cqw + 3.24rem, 6.1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.98rem",
+            "ideal": "2.33cqw + 3.24rem",
+            "max": "6.1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-5",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "5",
+          "deprecated": false
+        },
+        "key": "{type.scale.5}"
+      },
+      {
+        "$value": "clamp(4.78rem, 3.13cqw + 3.78rem, 7.63rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "4.78rem",
+            "ideal": "3.13cqw + 3.78rem",
+            "max": "7.63rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-6",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "6",
+          "deprecated": false
+        },
+        "key": "{type.scale.6}"
+      },
+      {
+        "$value": "clamp(5.73rem, 4.17cqw + 4.4rem, 9.54rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "5.73rem",
+            "ideal": "4.17cqw + 4.4rem",
+            "max": "9.54rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-7",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "7",
+          "deprecated": false
+        },
+        "key": "{type.scale.7}"
+      },
+      {
+        "$value": "clamp(1.33rem, 0.29cqw + 1.24rem, 1.6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.33rem",
+            "ideal": "0.29cqw + 1.24rem",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-minus-1",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "minus",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{type.scale.minus.1}"
+      },
+      {
+        "$value": "clamp(1.3rem, 0.29cqw + 1.24rem, 1.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.3rem",
+            "ideal": "0.29cqw + 1.24rem",
+            "max": "1.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-minus-2",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "minus",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{type.scale.minus.2}"
+      }
+    ]
+  },
+  "android": {
+    "misc": [],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [],
+    "radius": [],
+    "spacing": [],
+    "breakpoints": [],
+    "text": [
+      {
+        "$value": "34.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "34px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.size}"
+      },
+      {
+        "$value": "40.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Medium.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Medium.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.font-family}"
+      },
+      {
+        "$value": "26.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "26px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.size}"
+      },
+      {
+        "$value": "36.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "36px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.font-family}"
+      },
+      {
+        "$value": "24.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.size}"
+      },
+      {
+        "$value": "32.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.font-family}"
+      },
+      {
+        "$value": "19.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "19px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.size}"
+      },
+      {
+        "$value": "28.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "28px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.font-family}"
+      },
+      {
+        "$value": "17.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "17px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_headline_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.size}"
+      },
+      {
+        "$value": "24.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_headline_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_subheadline_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.size}"
+      },
+      {
+        "$value": "20.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_subheadline_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.size}"
+      },
+      {
+        "$value": "20.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.line-spacing}"
+      },
+      {
+        "$value": "12.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.size}"
+      },
+      {
+        "$value": "18.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "18px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.line-spacing}"
+      },
+      {
+        "$value": "12.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.size}"
+      },
+      {
+        "$value": "16.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.line-spacing}"
+      },
+      {
+        "$value": "11.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "11px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.size}"
+      },
+      {
+        "$value": "16.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_button_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.size}"
+      },
+      {
+        "$value": "24.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_button_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.line-spacing}"
+      }
+    ]
+  },
+  "ios": {
+    "misc": [],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [],
+    "radius": [],
+    "spacing": [
+      {
+        "$value": {
+          "min": "0.2rem",
+          "ideal": "0.1rem + 0.223cqi",
+          "max": "0.4rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+            "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+            "alternatives": [
+              {
+                "min": "0.2rem",
+                "ideal": "0.2rem + 0.11cqi",
+                "max": "0.3rem"
+              },
+              {
+                "min": "0.3rem",
+                "ideal": "0.3rem + 0.11cqi",
+                "max": "0.4rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.1rem + 0.223cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+              "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0--1}"
+      },
+      {
+        "$value": {
+          "min": "0.4rem",
+          "ideal": "0.2rem + 0.66cqi",
+          "max": "1rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+            "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+            "alternatives": [
+              {
+                "min": "0.8rem",
+                "ideal": "0.7rem + 0.22cqi",
+                "max": "1rem"
+              },
+              {
+                "min": "1.2rem",
+                "ideal": "1.1rem + 0.33cqi",
+                "max": "1.5rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.2rem + 0.66cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+              "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale34",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--4}"
+      },
+      {
+        "$value": {
+          "min": "0.8rem",
+          "ideal": "0.1404px + 1.21cqi",
+          "max": "1.6rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+            "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+            "alternatives": [
+              {
+                "min": "0.8rem",
+                "ideal": "0.7rem + 0.22cqi",
+                "max": "1rem"
+              },
+              {
+                "min": "1.2rem",
+                "ideal": "1.1rem + 0.33cqi",
+                "max": "1.5rem"
+              },
+              {
+                "min": "1.6rem",
+                "ideal": "1.5rem + 0.44cqi",
+                "max": "2rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.1404px + 1.21cqi",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+              "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}",
+                "{space.scale.5}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale35",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--5}"
+      }
+    ],
+    "breakpoints": [],
+    "text": [
+      {
+        "$value": "34.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "34px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.size}"
+      },
+      {
+        "$value": "40.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Medium.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Medium.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.font-family}"
+      },
+      {
+        "$value": "26.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "26px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.size}"
+      },
+      {
+        "$value": "36.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "36px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.font-family}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.size}"
+      },
+      {
+        "$value": "32.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.font-family}"
+      },
+      {
+        "$value": "19.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "19px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.size}"
+      },
+      {
+        "$value": "28.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "28px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.font-family}"
+      },
+      {
+        "$value": "17.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "17px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultHeadlineSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.size}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultHeadlineLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultSubheadlineSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.size}"
+      },
+      {
+        "$value": "20.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultSubheadlineLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.size}"
+      },
+      {
+        "$value": "20.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.line-spacing}"
+      },
+      {
+        "$value": "12.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.size}"
+      },
+      {
+        "$value": "18.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "18px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.line-spacing}"
+      },
+      {
+        "$value": "12.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.size}"
+      },
+      {
+        "$value": "16.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.line-spacing}"
+      },
+      {
+        "$value": "11.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "11px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.size}"
+      },
+      {
+        "$value": "16.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultButtonSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.size}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultButtonLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.line-spacing}"
+      }
+    ]
+  }
+}

--- a/dist/rei-dot-com/json/platform-tokens.json
+++ b/dist/rei-dot-com/json/platform-tokens.json
@@ -1,0 +1,24316 @@
+{
+  "global": {
+    "misc": [
+      {
+        "$type": "string",
+        "$value": "10",
+        "filePath": "tokens/_options/base.json",
+        "isSource": false,
+        "original": {
+          "$type": "string",
+          "$value": "10px"
+        },
+        "name": "cdr-text-size-root",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text-size-root}"
+      }
+    ],
+    "colors": [
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "accordion",
+          "example": "color",
+          "description": "Background color for the hover state of accordion"
+        },
+        "filePath": "tokens/global/accordion.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "accordion",
+            "example": "color",
+            "description": "Background color for the hover state of accordion"
+          }
+        },
+        "name": "cdr-color-background-accordion-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.accordion.hover}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-rest}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-active}"
+      },
+      {
+        "$value": "#c7dfd1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sage-green-400}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Alternate background color for the hover state of the icon button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Alternate background color for the hover state of the icon button"
+          }
+        },
+        "name": "cdr-color-background-button-primary-icon-alt-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.primary-icon-alt-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-active}"
+      },
+      {
+        "$value": "#f9f8f6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the disabled state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the disabled state of the secondary button"
+          }
+        },
+        "name": "cdr-color-background-button-secondary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.secondary-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-active}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-background-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.dark-hover}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-rest}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-active}"
+      },
+      {
+        "$value": "#fde2e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-background-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.sale-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Default disabled border color"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Default disabled border color"
+          }
+        },
+        "name": "cdr-color-background-button-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.default-disabled}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the icon only button active and focus states"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the icon only button active and focus states"
+          }
+        },
+        "name": "cdr-color-background-button-icon-only-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.button.icon-only-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for disabled chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for disabled chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-disabled}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for hovered chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for hovered chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for focused chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for focused chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-focus}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for active chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for active chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for hovered selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for hovered selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Background color for focused selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Background color for focused selected chips"
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "A transparent color option"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.transparent}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "A transparent color option"
+          }
+        },
+        "name": "cdr-color-background-transparent",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.transparent}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "The default, primary background color of most pages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "The default, primary background color of most pages"
+          }
+        },
+        "name": "cdr-color-background-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.primary}"
+      },
+      {
+        "$value": "#F4F2ED",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "An alternate, secondary background color used on some pages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "#F4F2ED",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "An alternate, secondary background color used on some pages"
+          }
+        },
+        "name": "cdr-color-background-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.secondary}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for sale messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for sale messages"
+          }
+        },
+        "name": "cdr-color-background-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.sale}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "An alternate, spruce brand background color used on some pages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "An alternate, spruce brand background color used on some pages"
+          }
+        },
+        "name": "cdr-color-background-brand-spruce",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.brand-spruce}"
+      },
+      {
+        "$value": "#ecf9e6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for success messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for success messages"
+          }
+        },
+        "name": "cdr-color-background-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.success}"
+      },
+      {
+        "$value": "#e2f4fe",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for informational messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for informational messages"
+          }
+        },
+        "name": "cdr-color-background-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.info}"
+      },
+      {
+        "$value": "#fdf6e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for warning messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for warning messages"
+          }
+        },
+        "name": "cdr-color-background-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.warning}"
+      },
+      {
+        "$value": "#fcefe4",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for error messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for error messages"
+          }
+        },
+        "name": "cdr-color-background-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.error}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-hover}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-active}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused state of a checkbox or radio label background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused state of a checkbox or radio label background"
+          }
+        },
+        "name": "cdr-color-background-label-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.default-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-active}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused state of a checkbox or radio label background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused state of a checkbox or radio label background on secondary"
+          }
+        },
+        "name": "cdr-color-background-label-secondary-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.label.secondary-focus}"
+      },
+      {
+        "$value": "rgba(247, 245, 243, 0.15)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025-15}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0.85)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white-85}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.secondary}"
+      },
+      {
+        "$value": "rgba(255, 242, 242, 0.75)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error background color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-050-75}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error background color on form elements"
+          }
+        },
+        "name": "cdr-color-background-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.error}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of a form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of a form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected state of a checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected state of a checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Active state of an input or select element background on secondary"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Active state of an input or select element background on secondary"
+          }
+        },
+        "name": "cdr-color-background-input-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.secondary-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected focus state of checkbox or radio element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected focus state of checkbox or radio element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-selected-focus}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused checkbox or radio form element background"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused checkbox or radio form element background"
+          }
+        },
+        "name": "cdr-color-background-input-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.input.default-focus}"
+      },
+      {
+        "$value": "#f9f8f6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for default messages"
+          }
+        },
+        "name": "cdr-color-background-message-default-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.default-01}"
+      },
+      {
+        "$value": "#e8e0ce",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for default messages"
+          }
+        },
+        "name": "cdr-color-background-message-default-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.default-02}"
+      },
+      {
+        "$value": "#ecf9e6",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success}"
+      },
+      {
+        "$value": "#f4fbf5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success-01}"
+      },
+      {
+        "$value": "#d5e6cb",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for success messages"
+          }
+        },
+        "name": "cdr-color-background-message-success-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.success-02}"
+      },
+      {
+        "$value": "#fdf6e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning}"
+      },
+      {
+        "$value": "#fefcf1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning-01}"
+      },
+      {
+        "$value": "#f5e9b7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-background-message-warning-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.warning-02}"
+      },
+      {
+        "$value": "#fcefe4",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error}"
+      },
+      {
+        "$value": "#fdf7f7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error-01}"
+      },
+      {
+        "$value": "#eecbc1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for error messages"
+          }
+        },
+        "name": "cdr-color-background-message-error-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.error-02}"
+      },
+      {
+        "$value": "#e2f4fe",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info}"
+      },
+      {
+        "$value": "#edf4f5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info-01}"
+      },
+      {
+        "$value": "#c2d8db",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-background-message-info-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.info-02}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "background",
+          "example": "color",
+          "description": "Background color for sale messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "background",
+            "example": "color",
+            "description": "Background color for sale messages"
+          }
+        },
+        "name": "cdr-color-background-message-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.message.sale}"
+      },
+      {
+        "$value": "rgba(247, 245, 243, 0.85)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "modal",
+          "example": "color",
+          "description": "The background overlay for modal"
+        },
+        "filePath": "tokens/global/modal.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025-85}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "modal",
+            "example": "color",
+            "description": "The background overlay for modal"
+          }
+        },
+        "name": "cdr-color-background-modal-overlay",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.modal.overlay}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "pagination",
+          "example": "color",
+          "description": "Background color for the hover state of pagination"
+        },
+        "filePath": "tokens/global/pagination.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "pagination",
+            "example": "color",
+            "description": "Background color for the hover state of pagination"
+          }
+        },
+        "name": "cdr-color-background-pagination-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.pagination.hover}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "pagination",
+          "example": "color",
+          "description": "Background color for the pagination keyline"
+        },
+        "filePath": "tokens/global/pagination.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "pagination",
+            "example": "color",
+            "description": "Background color for the pagination keyline"
+          }
+        },
+        "name": "cdr-color-background-pagination-keyline",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.pagination.keyline}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "The defaul background color of the rating star icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "The defaul background color of the rating star icon"
+          }
+        },
+        "name": "cdr-color-background-rating-star-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.rating-star.default}"
+      },
+      {
+        "$value": "#ffd280",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Background color for the highlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.golden-yellow-500}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Background color for the highlighted rating icon"
+          }
+        },
+        "name": "cdr-color-background-rating-star-highlighted",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.rating-star.highlighted}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the active state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the active state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the hover state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the hover state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the checked state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the checked state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-checked",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-checked}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the disabled state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the disabled state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-disabled}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Background color for the loading state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Background color for the loading state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-background-surface-selection-default-loading",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface-selection.default-loading}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the primary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the primary surface"
+          }
+        },
+        "name": "cdr-color-background-surface-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.primary}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the secondary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the secondary surface"
+          }
+        },
+        "name": "cdr-color-background-surface-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.secondary}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the brand-spruce surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the brand-spruce surface"
+          }
+        },
+        "name": "cdr-color-background-surface-brand-spruce",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.brand-spruce}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Background color for the sale surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Background color for the sale surface"
+          }
+        },
+        "name": "cdr-color-background-surface-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.surface.sale}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a switch on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a switch on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-rest}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "The background color of a selected switch on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "The background color of a selected switch on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.selected-default-focus}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Background color of a switch handle background when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Background color of a switch handle background when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-rest}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-default-focus}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle background when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle background when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-background-switch-handle-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.switch.handle-selected-default-focus}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The background color of table headers"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The background color of table headers"
+          }
+        },
+        "name": "cdr-color-background-table-header",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.header}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The background color of table rows"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The background color of table rows"
+          }
+        },
+        "name": "cdr-color-background-table-row",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.row}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "An alternate row color to aid grouping row data"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "An alternate row color to aid grouping row data"
+          }
+        },
+        "name": "cdr-color-background-table-row-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.table.row-alt}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle group",
+          "example": "color",
+          "description": "The background color of a toggle group on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle group",
+            "example": "color",
+            "description": "The background color of a toggle group on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-group-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-group.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-rest}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on hover"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on hover"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-hover}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a toggle button on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a toggle button on focus"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-focus}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a selected toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a selected toggle button on rest"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-selected-rest}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The background color of a selected toggle button on hover"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The background color of a selected toggle button on hover"
+          }
+        },
+        "name": "cdr-color-background-toggle-button-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.toggle-button.default-selected-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Background color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Background color for tooltips"
+          }
+        },
+        "name": "cdr-color-background-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.tooltip.default}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled primary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled primary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-primary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.primary-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled secondary buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled secondary buttons"
+          }
+        },
+        "name": "cdr-color-text-button-secondary-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.secondary-disabled}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of the dark button"
+          }
+        },
+        "name": "cdr-color-text-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled dark buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled dark buttons"
+          }
+        },
+        "name": "cdr-color-text-button-dark-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.dark-disabled}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-hover}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the active state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the active state of the sale button"
+          }
+        },
+        "name": "cdr-color-text-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-active}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "newToken": "",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for disabled sale buttons"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "newToken": "",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for disabled sale buttons"
+          }
+        },
+        "name": "cdr-color-text-button-sale-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.button.sale-disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Text color for default chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Text color for default chips"
+          }
+        },
+        "name": "cdr-color-text-chip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.chip.default}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Text color for default chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Text color for default chips"
+          }
+        },
+        "name": "cdr-color-text-chip-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.chip.disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The default, primary text color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The default, primary text color"
+          }
+        },
+        "name": "cdr-color-text-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.primary}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The secondary text color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The secondary text color"
+          }
+        },
+        "name": "cdr-color-text-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.secondary}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The emphasis text color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The emphasis text color"
+          }
+        },
+        "name": "cdr-color-text-emphasis",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.emphasis}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Text set in our primary brand color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Text set in our primary brand color"
+          }
+        },
+        "name": "cdr-color-text-brand",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.brand}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The color of sale text"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The color of sale text"
+          }
+        },
+        "name": "cdr-color-text-sale",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.sale}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Text color on dark background"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Text color on dark background"
+          }
+        },
+        "name": "cdr-color-text-inverse",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.inverse}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "The color of text when it is disabled"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "The color of text when it is disabled"
+          }
+        },
+        "name": "cdr-color-text-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.disabled}"
+      },
+      {
+        "$value": "#2e6b34",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of success messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of success messages"
+          }
+        },
+        "name": "cdr-color-text-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.success}"
+      },
+      {
+        "$value": "#854714",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of warning messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of warning messages"
+          }
+        },
+        "name": "cdr-color-text-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.warning}"
+      },
+      {
+        "$value": "#811823",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of error messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of error messages"
+          }
+        },
+        "name": "cdr-color-text-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.error}"
+      },
+      {
+        "$value": "#1b437e",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of informational messages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of informational messages"
+          }
+        },
+        "name": "cdr-color-text-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.info}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default text color used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default text color used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.default}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Color of label text used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Color of label text used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-label",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.label}"
+      },
+      {
+        "$value": "#b2ab9f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Color of label text used in disabled form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-450}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Color of label text used in disabled form elements"
+          }
+        },
+        "name": "cdr-color-text-input-label-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.label-disabled}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of placeholder text within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of placeholder text within forms"
+          }
+        },
+        "name": "cdr-color-text-input-placeholder",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.placeholder}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of required label within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of required label within forms"
+          }
+        },
+        "name": "cdr-color-text-input-required",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.required}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color of optional label within forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color of optional label within forms"
+          }
+        },
+        "name": "cdr-color-text-input-optional",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.optional}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled text color used in form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled text color used in form elements"
+          }
+        },
+        "name": "cdr-color-text-input-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.disabled}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Text color used in filled forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Text color used in filled forms"
+          }
+        },
+        "name": "cdr-color-text-input-filled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.filled}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Help text color used in forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Help text color used in forms"
+          }
+        },
+        "name": "cdr-color-text-input-help",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.help}"
+      },
+      {
+        "$value": "#b33322",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error text color used in forms"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-850}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error text color used in forms"
+          }
+        },
+        "name": "cdr-color-text-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.input.error}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for links"
+          }
+        },
+        "name": "cdr-color-text-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.rest}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the hover state of links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the hover state of links"
+          }
+        },
+        "name": "cdr-color-text-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.hover}"
+      },
+      {
+        "$value": "#0b2d60",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the active and pressed states of links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the active and pressed states of links"
+          }
+        },
+        "name": "cdr-color-text-link-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Disabled text color of links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Disabled text color of links"
+          }
+        },
+        "name": "cdr-color-text-link-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.disabled}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color of visited links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color of visited links"
+          }
+        },
+        "name": "cdr-color-text-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.link.visited}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "text",
+          "example": "color",
+          "description": "Color of error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "text",
+            "example": "color",
+            "description": "Color of error messages"
+          }
+        },
+        "name": "cdr-color-text-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.message.error}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.default}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for the hover state of ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for the hover state of ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.hover}"
+      },
+      {
+        "$value": "#b2ab9f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Text color for the separator in ratings"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-450}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Text color for the separator in ratings"
+          }
+        },
+        "name": "cdr-color-text-rating-separator",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.rating.separator}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for the active and pressed states of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for the active and pressed states of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.active}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Text color for the hover state of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Text color for the hover state of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Disabled text color of tabs"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Disabled text color of tabs"
+          }
+        },
+        "name": "cdr-color-text-tab-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tab.disabled}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "The text color of a toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "The text color of a toggle button on rest"
+          }
+        },
+        "name": "cdr-color-text-toggle-button-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.toggle-button.default-rest}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Text color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Text color for tooltips"
+          }
+        },
+        "name": "cdr-color-text-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.text.tooltip.default}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-rest}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-active}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-active-inset}"
+      },
+      {
+        "$value": "#1f513f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the primary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.blue-spruce-green-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-color-border-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.primary-hover}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-active}"
+      },
+      {
+        "$value": "#f7f5f3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-025}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-active-inset}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the secondary button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the secondary button"
+          }
+        },
+        "name": "cdr-color-border-button-secondary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.secondary-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-active}"
+      },
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-active-inset}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the dark button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the dark button"
+          }
+        },
+        "name": "cdr-color-border-button-dark-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.dark-hover}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-rest}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-active}"
+      },
+      {
+        "$value": "#fde2e2",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Inset border for the active state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-200}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Inset border for the active state of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-active-inset",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-active-inset}"
+      },
+      {
+        "$value": "#c7370f",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the sale button"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.sale-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the sale button"
+          }
+        },
+        "name": "cdr-color-border-button-sale-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.sale-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Default disabled border color"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Default disabled border color"
+          }
+        },
+        "name": "cdr-color-border-button-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the icon only button active and focus states"
+        },
+        "filePath": "tokens/global/button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the icon only button active and focus states"
+          }
+        },
+        "name": "cdr-color-border-button-icon-only-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.button.icon-only-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for disabled chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for disabled chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for hovered chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for hovered chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for focused chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for focused chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for active chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for active chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-rest}"
+      },
+      {
+        "$value": "#736e65",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for hovered selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-750}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for hovered selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "chip",
+          "example": "color",
+          "description": "Border color for focused selected chips"
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "chip",
+            "example": "color",
+            "description": "Border color for focused selected chips"
+          }
+        },
+        "name": "cdr-color-border-chip-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.chip.default-selected-focus}"
+      },
+      {
+        "$value": "rgba(255, 255, 255, 0)",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "A transparent color option"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.transparent}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "A transparent color option"
+          }
+        },
+        "name": "cdr-color-border-transparent",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.transparent}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Default border color for separating content"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Default border color for separating content"
+          }
+        },
+        "name": "cdr-color-border-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.primary}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "An alternate, secondary background color used on some pages"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "An alternate, secondary background color used on some pages"
+          }
+        },
+        "name": "cdr-color-border-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.secondary}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for success elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for success elements"
+          }
+        },
+        "name": "cdr-color-border-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for warning elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for warning elements"
+          }
+        },
+        "name": "cdr-color-border-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for error elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for error elements"
+          }
+        },
+        "name": "cdr-color-border-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.error}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color for informational elements"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color for informational elements"
+          }
+        },
+        "name": "cdr-color-border-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.info}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focused border color on checkbox or radio labels"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focused border color on checkbox or radio labels"
+          }
+        },
+        "name": "cdr-color-border-label-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.label.default-focus}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Default border color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Default border color on form elements"
+          }
+        },
+        "name": "cdr-color-border-input-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default}"
+      },
+      {
+        "$value": "#b33322",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Error border color on form elements"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-850}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Error border color on form elements"
+          }
+        },
+        "name": "cdr-color-border-input-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.error}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover/active/focus state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover/active/focus state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-active}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Selected state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Selected state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-selected}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Focus state of an input or select element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Focus state of an input or select element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-selected-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a checkbox or radio element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a checkbox or radio element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Disabled form element border"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Disabled form element border"
+          }
+        },
+        "name": "cdr-color-border-input-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.input.default-disabled}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.rest}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the hover state of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the hover state of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.hover}"
+      },
+      {
+        "$value": "#0b2d60",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the active and pressed states of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the active and pressed states of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.active}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Disabled border color of underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Disabled border color of underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.disabled}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color of visited underlined links"
+        },
+        "filePath": "tokens/global/link.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color of visited underlined links"
+          }
+        },
+        "name": "cdr-color-border-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.link.visited}"
+      },
+      {
+        "$value": "#726d64",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for default messages"
+          }
+        },
+        "name": "cdr-color-border-message-default-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.default-01}"
+      },
+      {
+        "$value": "#e8e0ce",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for default messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for default messages"
+          }
+        },
+        "name": "cdr-color-border-message-default-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.default-02}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for success messages"
+          }
+        },
+        "name": "cdr-color-border-message-success-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.success-01}"
+      },
+      {
+        "$value": "#d5e6cb",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for success messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for success messages"
+          }
+        },
+        "name": "cdr-color-border-message-success-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.success-02}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-border-message-warning-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.warning-01}"
+      },
+      {
+        "$value": "#f5e9b7",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for warning messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for warning messages"
+          }
+        },
+        "name": "cdr-color-border-message-warning-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.warning-02}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for error messages"
+          }
+        },
+        "name": "cdr-color-border-message-error-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.error-01}"
+      },
+      {
+        "$value": "#eecbc1",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for error messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for error messages"
+          }
+        },
+        "name": "cdr-color-border-message-error-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.error-02}"
+      },
+      {
+        "$value": "#408e86",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-border-message-info-01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.info-01}"
+      },
+      {
+        "$value": "#c2d8db",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "border",
+          "example": "color",
+          "description": "Border color variant for informational messages"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-300}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "border",
+            "example": "color",
+            "description": "Border color variant for informational messages"
+          }
+        },
+        "name": "cdr-color-border-message-info-02",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.message.info-02}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Default border color for the unhighlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Default border color for the unhighlighted rating icon"
+          }
+        },
+        "name": "cdr-color-border-rating-star-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.rating-star.default}"
+      },
+      {
+        "$value": "#bd7b2d",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "rating",
+          "example": "color",
+          "description": "Border color for the highlighted rating icon"
+        },
+        "filePath": "tokens/global/rating.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.golden-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "rating",
+            "example": "color",
+            "description": "Border color for the highlighted rating icon"
+          }
+        },
+        "name": "cdr-color-border-rating-star-highlighted",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.rating-star.highlighted}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-rest}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the active state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the active state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-active}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the hover state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the hover state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-hover}"
+      },
+      {
+        "$value": "#2e2e2b",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the checked state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the checked state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-checked",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-checked}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the disabled state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the disabled state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-disabled}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface selection",
+          "example": "color",
+          "description": "Border color for the loading state of the default surface selection"
+        },
+        "filePath": "tokens/global/surface-selection.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-700}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface selection",
+            "example": "color",
+            "description": "Border color for the loading state of the default surface selection"
+          }
+        },
+        "name": "cdr-color-border-surface-selection-default-loading",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface-selection.default-loading}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the primary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the primary surface"
+          }
+        },
+        "name": "cdr-color-border-surface-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.primary}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the secondary surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the secondary surface"
+          }
+        },
+        "name": "cdr-color-border-surface-secondary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.secondary}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the success surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the success surface"
+          }
+        },
+        "name": "cdr-color-border-surface-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the warning surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the warning surface"
+          }
+        },
+        "name": "cdr-color-border-surface-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the error surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the error surface"
+          }
+        },
+        "name": "cdr-color-border-surface-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.error}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "surface",
+          "example": "color",
+          "description": "Border color for the info surface"
+        },
+        "filePath": "tokens/global/surface.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "surface",
+            "example": "color",
+            "description": "Border color for the info surface"
+          }
+        },
+        "name": "cdr-color-border-surface-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.surface.info}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Border color for a switch that is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Border color for a switch that is not selected on hover"
+          }
+        },
+        "name": "cdr-color-border-switch-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on rest"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on rest"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on hover"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch handle border when the switch is not selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch handle border when the switch is not selected on focus"
+          }
+        },
+        "name": "cdr-color-border-switch-handle-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.switch.handle-default-focus}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "The border color of tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "The border color of tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-rest}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the active tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the active tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-active}"
+      },
+      {
+        "$value": "#78b1e8",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Alternative border color for the active tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Alternative border color for the active tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-active-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-active-alt}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the tab keyline hover state"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the tab keyline hover state"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-hover}"
+      },
+      {
+        "$value": "#78b1e8",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Alternative border color for the tab keyline hover state"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Alternative border color for the tab keyline hover state"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-hover-alt",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-hover-alt}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tabs",
+          "example": "color",
+          "description": "Border color for the disabled tab keyline"
+        },
+        "filePath": "tokens/global/tab.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tabs",
+            "example": "color",
+            "description": "Border color for the disabled tab keyline"
+          }
+        },
+        "name": "cdr-color-border-tab-keyline-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tab.keyline-disabled}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "The border color of table rows and their corresponding data cells"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "The border color of table rows and their corresponding data cells"
+          }
+        },
+        "name": "cdr-color-border-table-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.table.default}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "table",
+          "example": "color",
+          "description": "Border color separating complex table heads"
+        },
+        "filePath": "tokens/global/table.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "table",
+            "example": "color",
+            "description": "Border color separating complex table heads"
+          }
+        },
+        "name": "cdr-color-border-table-head",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.table.head}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a toggle button that is not selected on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a toggle button that is not selected on focus"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-focus}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a selected toggle button on rest"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a selected toggle button on rest"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-selected-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-selected-rest}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "toggle button",
+          "example": "color",
+          "description": "Border color for a selected toggle on focus"
+        },
+        "filePath": "tokens/global/toggle-button.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "toggle button",
+            "example": "color",
+            "description": "Border color for a selected toggle on focus"
+          }
+        },
+        "name": "cdr-color-border-toggle-button-default-selected-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.toggle-button.default-selected-focus}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "tooltip",
+          "example": "color",
+          "description": "Border color for tooltips"
+        },
+        "filePath": "tokens/global/tooltip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "tooltip",
+            "example": "color",
+            "description": "Border color for tooltips"
+          }
+        },
+        "name": "cdr-color-border-tooltip-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.border.tooltip.default}"
+      },
+      {
+        "$value": "#958e83",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The default icon color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-600}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The default icon color"
+          }
+        },
+        "name": "cdr-color-icon-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.default}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "Emphasis or darkest icon color on a light background"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "Emphasis or darkest icon color on a light background"
+          }
+        },
+        "name": "cdr-color-icon-emphasis",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.emphasis}"
+      },
+      {
+        "$value": "#406eb5",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The icon link color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.alpine-lake-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The icon link color"
+          }
+        },
+        "name": "cdr-color-icon-link",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.link}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The disabled icon color"
+        },
+        "filePath": "tokens/global/color.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The disabled icon color"
+          }
+        },
+        "name": "cdr-color-icon-disabled",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.disabled}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Rest state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Rest state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected}"
+      },
+      {
+        "$value": "#ffffff",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.white}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected-hover}"
+      },
+      {
+        "$value": "#4b4a48",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "input",
+          "example": "color",
+          "description": "Hover state of a selected form icon"
+        },
+        "filePath": "tokens/global/input.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-900}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "input",
+            "example": "color",
+            "description": "Hover state of a selected form icon"
+          }
+        },
+        "name": "cdr-color-icon-checkbox-default-selected-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.checkbox.default-selected-active}"
+      },
+      {
+        "$value": "#726d64",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The default message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.default-grey-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The default message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.default}"
+      },
+      {
+        "$value": "#3b8349",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The success message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.success-green-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The success message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-success",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.success}"
+      },
+      {
+        "$value": "#b68b37",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The warning message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warning-yellow-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The warning message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-warning",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.warning}"
+      },
+      {
+        "$value": "#bb4045",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The error message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.error-red-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The error message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-error",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.error}"
+      },
+      {
+        "$value": "#408e86",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "icon",
+          "example": "color",
+          "description": "The informational message icon color"
+        },
+        "filePath": "tokens/global/message.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.info-blue-800}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "icon",
+            "example": "color",
+            "description": "The informational message icon color"
+          }
+        },
+        "name": "cdr-color-icon-message-info",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.message.info}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-rest}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected on hover"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected on hover"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-hover}"
+      },
+      {
+        "$value": "#d5cfc3",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "switch",
+          "example": "color",
+          "description": "Color of a switch icon when the switch is selected on focus"
+        },
+        "filePath": "tokens/global/switch.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-250}",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "switch",
+            "example": "color",
+            "description": "Color of a switch icon when the switch is selected on focus"
+          }
+        },
+        "name": "cdr-color-icon-switch-selected-default-focus",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.icon.switch.selected-default-focus}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of primary buttons"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of primary buttons"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-text-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.text.button.primary-hover}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "type": "text",
+          "example": "color",
+          "category": "colors"
+        },
+        "filePath": "tokens/themes/rei-dot-com/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "type": "text",
+            "example": "color",
+            "category": "colors"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-text-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.text.primary}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-text-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.text.link.rest}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the hover state of links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the hover state of links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-text-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.text.link.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color of visited links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color of visited links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-text-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.text.link.visited}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the primary button"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-background-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.background.button.primary.rest}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-background-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.background.button.primary.active}"
+      },
+      {
+        "$value": "#ffdc52",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "example": "color",
+          "category": "colors"
+        },
+        "filePath": "tokens/themes/rei-dot-com/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "#ffdc52",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "example": "color",
+            "category": "colors"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-background-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.background.primary}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the primary button"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.button.primary.rest}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.button.primary.active}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.button.primary.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for underlined links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.link.rest}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the hover state of underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the hover state of underlined links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.link.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color of visited underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color of visited underlined links"
+          }
+        },
+        "name": "cdr-membership-vibrant-color-border-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.vibrant.color.border.link.visited}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Text color for the hover state of primary buttons"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Text color for the hover state of primary buttons"
+          }
+        },
+        "name": "cdr-membership-subtle-color-text-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.text.button.primary-hover}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "type": "text",
+          "example": "color",
+          "category": "colors"
+        },
+        "filePath": "tokens/themes/rei-dot-com/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "type": "text",
+            "example": "color",
+            "category": "colors"
+          }
+        },
+        "name": "cdr-membership-subtle-color-text-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.text.primary}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-text-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.text.link.rest}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color for the hover state of links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color for the hover state of links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-text-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.text.link.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Text color of visited links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Text color of visited links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-text-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.text.link.visited}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the primary button"
+          }
+        },
+        "name": "cdr-membership-subtle-color-background-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.background.button.primary.rest}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Background color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Background color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-membership-subtle-color-background-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.background.button.primary.active}"
+      },
+      {
+        "$value": "#bfb33e",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "example": "color",
+          "category": "colors"
+        },
+        "filePath": "tokens/themes/rei-dot-com/color.json",
+        "isSource": true,
+        "original": {
+          "$value": "#bfb33e",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "example": "color",
+            "category": "colors"
+          }
+        },
+        "name": "cdr-membership-subtle-color-background-primary",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.background.primary}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the primary button"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-button-primary-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.button.primary.rest}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the active and pressed states of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the active and pressed states of the primary button"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-button-primary-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.button.primary.active}"
+      },
+      {
+        "$value": "#13352c",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "button",
+          "example": "color",
+          "description": "Border color for the hover state of the primary button"
+        },
+        "filePath": "tokens/themes/rei-dot-com/button.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352c",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "button",
+            "example": "color",
+            "description": "Border color for the hover state of the primary button"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-button-primary-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.button.primary.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for underlined links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-link-rest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.link.rest}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color for the hover state of underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color for the hover state of underlined links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-link-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.link.hover}"
+      },
+      {
+        "$value": "#13352C",
+        "$type": "color",
+        "docs": {
+          "category": "colors",
+          "type": "link",
+          "example": "color",
+          "description": "Border color of visited underlined links"
+        },
+        "filePath": "tokens/themes/rei-dot-com/link.json",
+        "isSource": true,
+        "original": {
+          "$value": "#13352C",
+          "$type": "color",
+          "docs": {
+            "category": "colors",
+            "type": "link",
+            "example": "color",
+            "description": "Border color of visited underlined links"
+          }
+        },
+        "name": "cdr-membership-subtle-color-border-link-visited",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{membership.subtle.color.border.link.visited}"
+      }
+    ],
+    "color": [
+      {
+        "$value": "#edeae3",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "chip-default-selected-active",
+          "description": {
+            "what": "Active background for selected chips",
+            "when": "Use when a chip is selected and active"
+          }
+        },
+        "filePath": "tokens/global/chip.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-100}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "chip-default-selected-active",
+            "description": {
+              "what": "Active background for selected chips",
+              "when": "Use when a chip is selected and active"
+            }
+          }
+        },
+        "name": "cdr-color-background-chip-default-selected-active",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.chip.default-selected-active}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "slide-default",
+          "description": {
+            "what": "Default slide background color",
+            "when": "Use for the resting state of slide surfaces."
+          }
+        },
+        "filePath": "tokens/global/slide.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "slide-default",
+            "description": {
+              "what": "Default slide background color",
+              "when": "Use for the resting state of slide surfaces."
+            }
+          }
+        },
+        "name": "cdr-color-background-slide-hover",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.slide.hover}"
+      },
+      {
+        "$value": "#fafbf9",
+        "$type": "color",
+        "docs": {
+          "type": "background",
+          "category": "color",
+          "example": "slide-hover",
+          "description": {
+            "what": "Hover background color for slide surfaces",
+            "when": "Use when a slide component is hovered",
+            "alternatives": [
+              "#fafbf9"
+            ]
+          }
+        },
+        "filePath": "tokens/global/slide.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-010}",
+          "$type": "color",
+          "docs": {
+            "type": "background",
+            "category": "color",
+            "example": "slide-hover",
+            "description": {
+              "what": "Hover background color for slide surfaces",
+              "when": "Use when a slide component is hovered",
+              "alternatives": [
+                "{color.background.slide.default}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-color-background-slide-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{color.background.slide.default}"
+      }
+    ],
+    "form": [
+      {
+        "$value": "4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "height",
+          "category": "form",
+          "example": "height-default",
+          "description": {
+            "what": "Default input height",
+            "when": "Use for standard form fields",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "docs": {
+            "type": "height",
+            "category": "form",
+            "example": "height-default",
+            "description": {
+              "what": "Default input height",
+              "when": "Use for standard form fields",
+              "alternatives": [
+                "{form.input.height-large}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-input-height-default",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.input.height-default}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "height",
+          "category": "form",
+          "example": "height-large",
+          "description": {
+            "what": "Large input height",
+            "when": "Use for spacious layouts"
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "48px",
+          "$type": "dimension",
+          "docs": {
+            "type": "height",
+            "category": "form",
+            "example": "height-large",
+            "description": {
+              "what": "Large input height",
+              "when": "Use for spacious layouts"
+            }
+          }
+        },
+        "name": "cdr-form-input-height-large",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.input.height-large}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-small",
+          "description": {
+            "what": "Small figure size",
+            "when": "Use for compact forms",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-small",
+            "description": {
+              "what": "Small figure size",
+              "when": "Use for compact forms",
+              "alternatives": [
+                "{form.figure.size-medium}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-small",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-small}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-medium",
+          "description": {
+            "what": "Medium figure size",
+            "when": "Use for standard forms",
+            "alternatives": [
+              "2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-medium",
+            "description": {
+              "what": "Medium figure size",
+              "when": "Use for standard forms",
+              "alternatives": [
+                "{form.figure.size-large}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-medium",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-medium}"
+      },
+      {
+        "$value": "2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "form",
+          "example": "size-large",
+          "description": {
+            "what": "Large figure size",
+            "when": "Use for large or expressive forms"
+          }
+        },
+        "filePath": "tokens/global/form.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "form",
+            "example": "size-large",
+            "description": {
+              "what": "Large figure size",
+              "when": "Use for large or expressive forms"
+            }
+          }
+        },
+        "name": "cdr-form-figure-size-large",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{form.figure.size-large}"
+      }
+    ],
+    "icon": [
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size-sm",
+          "description": {
+            "what": "Small icon size",
+            "when": "Use for dense UI",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size-sm",
+            "description": {
+              "what": "Small icon size",
+              "when": "Use for dense UI",
+              "alternatives": [
+                "{icon.size}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-icon-size-sm",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size-sm}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size",
+          "description": {
+            "what": "Default icon size",
+            "when": "Use for standard UI",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size",
+            "description": {
+              "what": "Default icon size",
+              "when": "Use for standard UI",
+              "alternatives": [
+                "{icon.size-lg}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-icon-size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "size",
+          "category": "icon",
+          "example": "size-lg",
+          "description": {
+            "what": "Large icon size",
+            "when": "Use for prominent UI elements"
+          }
+        },
+        "filePath": "tokens/global/icon.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "size",
+            "category": "icon",
+            "example": "size-lg",
+            "description": {
+              "what": "Large icon size",
+              "when": "Use for prominent UI elements"
+            }
+          }
+        },
+        "name": "cdr-icon-size-lg",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{icon.size-lg}"
+      }
+    ],
+    "motion": [
+      {
+        "$value": "0.10s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-1-x",
+          "description": {
+            "what": "Very short animation duration",
+            "when": "Use for micro-interactions",
+            "alternatives": [
+              "0.20s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "100ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-1-x",
+            "description": {
+              "what": "Very short animation duration",
+              "when": "Use for micro-interactions",
+              "alternatives": [
+                "{duration.2-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-1-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.1-x}"
+      },
+      {
+        "$value": "0.20s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-2-x",
+          "description": {
+            "what": "Short animation duration",
+            "when": "Use for quick UI transitions",
+            "alternatives": [
+              "0.30s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "200ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-2-x",
+            "description": {
+              "what": "Short animation duration",
+              "when": "Use for quick UI transitions",
+              "alternatives": [
+                "{duration.3-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-2-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.2-x}"
+      },
+      {
+        "$value": "0.30s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-3-x",
+          "description": {
+            "what": "Medium duration",
+            "when": "Use for standard UI animations",
+            "alternatives": [
+              "0.40s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "300ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-3-x",
+            "description": {
+              "what": "Medium duration",
+              "when": "Use for standard UI animations",
+              "alternatives": [
+                "{duration.4-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-3-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.3-x}"
+      },
+      {
+        "$value": "0.40s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-4-x",
+          "description": {
+            "what": "Long duration",
+            "when": "Use for slower transitions",
+            "alternatives": [
+              "0.50s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "400ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-4-x",
+            "description": {
+              "what": "Long duration",
+              "when": "Use for slower transitions",
+              "alternatives": [
+                "{duration.5-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-4-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.4-x}"
+      },
+      {
+        "$value": "0.50s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-5-x",
+          "description": {
+            "what": "Very long duration",
+            "when": "Use for dramatic or modal transitions",
+            "alternatives": [
+              "0.60s"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "500ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-5-x",
+            "description": {
+              "what": "Very long duration",
+              "when": "Use for dramatic or modal transitions",
+              "alternatives": [
+                "{duration.6-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-duration-5-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.5-x}"
+      },
+      {
+        "$value": "0.60s",
+        "$type": "time",
+        "docs": {
+          "type": "duration",
+          "category": "motion",
+          "example": "duration-6-x",
+          "description": {
+            "what": "Extra long duration",
+            "when": "Use sparingly for large UI shifts"
+          }
+        },
+        "filePath": "tokens/global/motion-duration.json",
+        "isSource": false,
+        "original": {
+          "$value": "600ms",
+          "$type": "time",
+          "docs": {
+            "type": "duration",
+            "category": "motion",
+            "example": "duration-6-x",
+            "description": {
+              "what": "Extra long duration",
+              "when": "Use sparingly for large UI shifts"
+            }
+          }
+        },
+        "name": "cdr-duration-6-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{duration.6-x}"
+      },
+      {
+        "$value": "cubic-bezier(0.32, 0.94, 0.60, 1)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "ease-out",
+          "description": {
+            "what": "Ease-out timing curve",
+            "when": "Use when animations should decelerate smoothly",
+            "alternatives": [
+              "cubic-bezier(0.15, 0, 0.15, 0)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0.32, 0.94, 0.60, 1)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "ease-out",
+            "description": {
+              "what": "Ease-out timing curve",
+              "when": "Use when animations should decelerate smoothly",
+              "alternatives": [
+                "{timing.function-ease}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-timing-function-ease-out",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-ease-out}"
+      },
+      {
+        "$value": "cubic-bezier(0.15, 0, 0.15, 0)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "ease",
+          "description": {
+            "what": "Ease timing curve",
+            "when": "Use for general-purpose animations",
+            "alternatives": [
+              "cubic-bezier(0, 0, 1, 1)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0.15, 0, 0.15, 0)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "ease",
+            "description": {
+              "what": "Ease timing curve",
+              "when": "Use for general-purpose animations",
+              "alternatives": [
+                "{timing.function-linear}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-timing-function-ease",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-ease}"
+      },
+      {
+        "$value": "cubic-bezier(0, 0, 1, 1)",
+        "$type": "function",
+        "docs": {
+          "type": "timing-function",
+          "category": "motion",
+          "example": "linear",
+          "description": {
+            "what": "Linear timing curve",
+            "when": "Use for constant-speed animations"
+          }
+        },
+        "filePath": "tokens/global/motion-timing.json",
+        "isSource": false,
+        "original": {
+          "$value": "cubic-bezier(0, 0, 1, 1)",
+          "$type": "function",
+          "docs": {
+            "type": "timing-function",
+            "category": "motion",
+            "example": "linear",
+            "description": {
+              "what": "Linear timing curve",
+              "when": "Use for constant-speed animations"
+            }
+          }
+        },
+        "name": "cdr-timing-function-linear",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{timing.function-linear}"
+      }
+    ],
+    "prominence": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-x",
+          "description": {
+            "what": "X for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-x",
+            "description": {
+              "what": "X for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-x}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-y",
+          "description": {
+            "what": "Y for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-y",
+            "description": {
+              "what": "Y for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-y}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-blur",
+          "description": {
+            "what": "Blur for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-blur",
+            "description": {
+              "what": "Blur for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-spread",
+          "description": {
+            "what": "Spread for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-spread",
+            "description": {
+              "what": "Spread for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "flat-color",
+          "description": {
+            "what": "Color for flat level",
+            "when": "Use for flat surfaces needing minimal depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "flat-color",
+            "description": {
+              "what": "Color for flat level",
+              "when": "Use for flat surfaces needing minimal depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-flat-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.flat-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-x",
+          "description": {
+            "what": "X for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-x",
+            "description": {
+              "what": "X for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-y",
+          "description": {
+            "what": "Y for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-y",
+            "description": {
+              "what": "Y for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-y}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-blur",
+          "description": {
+            "what": "Blur for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-blur",
+            "description": {
+              "what": "Blur for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-spread",
+          "description": {
+            "what": "Spread for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-spread",
+            "description": {
+              "what": "Spread for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "raised-color",
+          "description": {
+            "what": "Color for raised level",
+            "when": "Use for raised surfaces needing subtle elevation"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "raised-color",
+            "description": {
+              "what": "Color for raised level",
+              "when": "Use for raised surfaces needing subtle elevation"
+            }
+          }
+        },
+        "name": "cdr-prominence-raised-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.raised-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-x",
+          "description": {
+            "what": "X for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-x",
+            "description": {
+              "what": "X for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-y",
+          "description": {
+            "what": "Y for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-y",
+            "description": {
+              "what": "Y for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-y}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-blur",
+          "description": {
+            "what": "Blur for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-blur",
+            "description": {
+              "what": "Blur for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-spread",
+          "description": {
+            "what": "Spread for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-spread",
+            "description": {
+              "what": "Spread for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "elevated-color",
+          "description": {
+            "what": "Color for elevated level",
+            "when": "Use for elevated surfaces needing medium depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "elevated-color",
+            "description": {
+              "what": "Color for elevated level",
+              "when": "Use for elevated surfaces needing medium depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-elevated-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.elevated-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-x",
+          "description": {
+            "what": "X for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-x",
+            "description": {
+              "what": "X for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-y",
+          "description": {
+            "what": "Y for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "8px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-y",
+            "description": {
+              "what": "Y for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-y}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-blur",
+          "description": {
+            "what": "Blur for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "8px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-blur",
+            "description": {
+              "what": "Blur for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-spread",
+          "description": {
+            "what": "Spread for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-spread",
+            "description": {
+              "what": "Spread for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "floating-color",
+          "description": {
+            "what": "Color for floating level",
+            "when": "Use for floating surfaces needing strong depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "floating-color",
+            "description": {
+              "what": "Color for floating level",
+              "when": "Use for floating surfaces needing strong depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-floating-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.floating-color}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-x",
+          "description": {
+            "what": "X for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-x",
+            "description": {
+              "what": "X for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-y",
+          "description": {
+            "what": "Y for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-y",
+            "description": {
+              "what": "Y for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-y",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-y}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-blur",
+          "description": {
+            "what": "Blur for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-blur",
+            "description": {
+              "what": "Blur for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-blur",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-blur}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-spread",
+          "description": {
+            "what": "Spread for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-spread",
+            "description": {
+              "what": "Spread for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-spread",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-spread}"
+      },
+      {
+        "$value": "rgba(46, 46, 43, 0.2)",
+        "$type": "color",
+        "docs": {
+          "type": "shadow",
+          "category": "prominence",
+          "example": "lifted-color",
+          "description": {
+            "what": "Color for lifted level",
+            "when": "Use for lifted surfaces needing dramatic depth"
+          }
+        },
+        "filePath": "tokens/global/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.color.warm-grey-1000-20}",
+          "$type": "color",
+          "docs": {
+            "type": "shadow",
+            "category": "prominence",
+            "example": "lifted-color",
+            "description": {
+              "what": "Color for lifted level",
+              "when": "Use for lifted surfaces needing dramatic depth"
+            }
+          }
+        },
+        "name": "cdr-prominence-lifted-color",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{prominence.lifted-color}"
+      }
+    ],
+    "radius": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "sharp",
+          "description": {
+            "what": "Zero-radius corner",
+            "when": "Use for crisp, squared edges",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "sharp",
+            "description": {
+              "what": "Zero-radius corner",
+              "when": "Use for crisp, squared edges",
+              "alternatives": [
+                "{radius.soft}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-sharp",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.sharp}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "soft",
+          "description": {
+            "what": "Small, subtle corner radius",
+            "when": "Use for gentle rounding",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "soft",
+            "description": {
+              "what": "Small, subtle corner radius",
+              "when": "Use for gentle rounding",
+              "alternatives": [
+                "{radius.softer}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-soft",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.soft}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "softer",
+          "description": {
+            "what": "Medium corner radius",
+            "when": "Use for more noticeable rounding",
+            "alternatives": [
+              "0.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "softer",
+            "description": {
+              "what": "Medium corner radius",
+              "when": "Use for more noticeable rounding",
+              "alternatives": [
+                "{radius.softest}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-softer",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.softer}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "softest",
+          "description": {
+            "what": "Large rounded corner",
+            "when": "Use for pill-like shapes",
+            "alternatives": [
+              "0.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "6px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "softest",
+            "description": {
+              "what": "Large rounded corner",
+              "when": "Use for pill-like shapes",
+              "alternatives": [
+                "{radius.softest}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-radius-softest",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.softest}"
+      },
+      {
+        "$value": "999.9rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "corner",
+          "category": "radius",
+          "example": "round",
+          "description": {
+            "what": "Fully circular radius",
+            "when": "Use for circular elements"
+          }
+        },
+        "filePath": "tokens/global/radius.json",
+        "isSource": false,
+        "original": {
+          "$value": "9999px",
+          "$type": "dimension",
+          "docs": {
+            "type": "corner",
+            "category": "radius",
+            "example": "round",
+            "description": {
+              "what": "Fully circular radius",
+              "when": "Use for circular elements"
+            }
+          }
+        },
+        "name": "cdr-radius-round",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{radius.round}"
+      }
+    ],
+    "spacing": [
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Zero spacing, removes all space between elements.",
+            "when": "Use when elements must be flush against each other with no gap."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.zero}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Zero spacing, removes all space between elements.",
+              "when": "Use when elements must be flush against each other with no gap."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-zero",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.zero}"
+      },
+      {
+        "$value": "0.1rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "The smallest static spacing unit, one-sixteenth of the base.",
+            "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "The smallest static spacing unit, one-sixteenth of the base.",
+              "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.sixteenth-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-eighth of the base unit.",
+            "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-eighth of the base unit.",
+              "when": "Use for legacy components only. No direct scale equivalent — scale.0 is the closest but produces slightly larger spacing.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.eighth-x}"
+      },
+      {
+        "$value": "0.3rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-sixteenths of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-sixteenths of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.0}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-sixteenth-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-quarter of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-quarter of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.quarter-x}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-eighths of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-eighths of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.1}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-eighth-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one-half of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.4rem, 0.4rem + 0.11cqi, 0.5rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one-half of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.2}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.half-x}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three-quarters of the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three-quarters of the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.3}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-quarter-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "The base static spacing unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "The base static spacing unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.3}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-one-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.one-x}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at one and a half times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at one and a half times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.4}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-one-and-a-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.one-and-a-half-x}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at two times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at two times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.5}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-two-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.two-x}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at three times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(2.4rem, 2.2rem + 0.66cqi, 3rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "48px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at three times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.6}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-three-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.three-x}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Static spacing at four times the base unit.",
+            "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+            "alternatives": [
+              "clamp(3.2rem, 2.9rem + 0.88cqi, 4rem)"
+            ]
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "64px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Static spacing at four times the base unit.",
+              "when": "Use for legacy components only. Prefer fluid scale tokens for new work.",
+              "alternatives": [
+                "{space.scale.7}"
+              ]
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-four-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.four-x}"
+      },
+      {
+        "$value": "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "The smallest fluid spacing step, scaling from 3.2px to 4.8px.",
+            "when": "Use for the tightest gaps between inline elements such as an icon and a label."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.2rem + 0.11cqi",
+            "max": "0.3rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "The smallest fluid spacing step, scaling from 3.2px to 4.8px.",
+              "when": "Use for the tightest gaps between inline elements such as an icon and a label."
+            }
+          }
+        },
+        "name": "cdr-space-scale-0",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0}"
+      },
+      {
+        "$value": "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 1, scaling from 4.8px to 6.4px.",
+            "when": "Use for minimal separation between closely related elements."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.3rem",
+            "ideal": "0.3rem + 0.11cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 1, scaling from 4.8px to 6.4px.",
+              "when": "Use for minimal separation between closely related elements."
+            }
+          }
+        },
+        "name": "cdr-space-scale-1",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.1}"
+      },
+      {
+        "$value": "clamp(0.4rem, 0.4rem + 0.11cqi, 0.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 2, scaling from 6.4px to 8px.",
+            "when": "Use for small gaps such as between stacked text elements or tight component internals."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.4rem + 0.11cqi",
+            "max": "0.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 2, scaling from 6.4px to 8px.",
+              "when": "Use for small gaps such as between stacked text elements or tight component internals."
+            }
+          }
+        },
+        "name": "cdr-space-scale-2",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.2}"
+      },
+      {
+        "$value": "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 3, scaling from 12.8px to 16px. Equivalent to the static base unit.",
+            "when": "Use for spacing between related components such as form fields or list items."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.7rem + 0.22cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 3, scaling from 12.8px to 16px. Equivalent to the static base unit.",
+              "when": "Use for spacing between related components such as form fields or list items."
+            }
+          }
+        },
+        "name": "cdr-space-scale-3",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3}"
+      },
+      {
+        "$value": "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 4, scaling from 19.2px to 24px.",
+            "when": "Use for spacing between distinct components or content groups."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.2rem",
+            "ideal": "1.1rem + 0.33cqi",
+            "max": "1.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 4, scaling from 19.2px to 24px.",
+              "when": "Use for spacing between distinct components or content groups."
+            }
+          }
+        },
+        "name": "cdr-space-scale-4",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.4}"
+      },
+      {
+        "$value": "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 5, scaling from 25.6px to 32px.",
+            "when": "Use for separation between major content sections."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.6rem",
+            "ideal": "1.5rem + 0.44cqi",
+            "max": "2rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 5, scaling from 25.6px to 32px.",
+              "when": "Use for separation between major content sections."
+            }
+          }
+        },
+        "name": "cdr-space-scale-5",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.5}"
+      },
+      {
+        "$value": "clamp(2.4rem, 2.2rem + 0.66cqi, 3rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 6, scaling from 38.4px to 48px.",
+            "when": "Use for generous separation between page-level sections."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.4rem",
+            "ideal": "2.2rem + 0.66cqi",
+            "max": "3rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 6, scaling from 38.4px to 48px.",
+              "when": "Use for generous separation between page-level sections."
+            }
+          }
+        },
+        "name": "cdr-space-scale-6",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.6}"
+      },
+      {
+        "$value": "clamp(3.2rem, 2.9rem + 0.88cqi, 4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing step 7, scaling from 51.2px to 64px.",
+            "when": "Use for large layout gaps such as between hero sections and page content."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.2rem",
+            "ideal": "2.9rem + 0.88cqi",
+            "max": "4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing step 7, scaling from 51.2px to 64px.",
+              "when": "Use for large layout gaps such as between hero sections and page content."
+            }
+          }
+        },
+        "name": "cdr-space-scale-7",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.7}"
+      },
+      {
+        "$value": "clamp(4.8rem, 4.4rem + 1.31cqi, 6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "The largest fluid spacing step, scaling from 76.8px to 96px.",
+            "when": "Use for major page-level separation such as between full-width content blocks."
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "4.8rem",
+            "ideal": "4.4rem + 1.31cqi",
+            "max": "6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "The largest fluid spacing step, scaling from 76.8px to 96px.",
+              "when": "Use for major page-level separation such as between full-width content blocks."
+            }
+          }
+        },
+        "name": "cdr-space-scale-8",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.8}"
+      },
+      {
+        "$value": "clamp(0.2rem, 0.1rem + 0.223cqi, 0.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+            "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+            "alternatives": [
+              "clamp(0.2rem, 0.2rem + 0.11cqi, 0.3rem)",
+              "clamp(0.3rem, 0.3rem + 0.11cqi, 0.4rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.1rem + 0.223cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+              "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-0-1",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0--1}"
+      },
+      {
+        "$value": "clamp(0.4rem, 0.2rem + 0.66cqi, 1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+            "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.2rem + 0.66cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+              "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-3-4",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--4}"
+      },
+      {
+        "$value": "clamp(0.8rem, 0.1404px + 1.21cqi, 1.6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+            "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+            "alternatives": [
+              "clamp(0.8rem, 0.7rem + 0.22cqi, 1rem)",
+              "clamp(1.2rem, 1.1rem + 0.33cqi, 1.5rem)",
+              "clamp(1.6rem, 1.5rem + 0.44cqi, 2rem)"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.1404px + 1.21cqi",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+              "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}",
+                "{space.scale.5}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-scale-3-5",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--5}"
+      },
+      {
+        "$value": "0.1rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-sixteenth of the base unit.",
+            "when": "Use for the tightest padding on very small components such as micro badges."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-sixteenth of the base unit.",
+              "when": "Use for the tightest padding on very small components such as micro badges."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.sixteenth-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-eighth of the base unit.",
+            "when": "Use for compact components such as badges or tags."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-eighth of the base unit.",
+              "when": "Use for compact components such as badges or tags."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x}"
+      },
+      {
+        "$value": "0",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished eighth-x inset, compressed to zero.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished eighth-x inset, compressed to zero.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished eighth-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished eighth-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish-left-right}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched eighth-x inset, expanded beyond the base.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "4px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched eighth-x inset, expanded beyond the base.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched eighth-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "2px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched eighth-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.eighth-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-eighth-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch-left-right}"
+      },
+      {
+        "$value": "0.3rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-sixteenths of the base unit.",
+            "when": "Use for compact components needing slightly more padding than eighth-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-sixteenth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-sixteenths of the base unit.",
+              "when": "Use for compact components needing slightly more padding than eighth-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-sixteenth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-sixteenth-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-quarter of the base unit.",
+            "when": "Use for small components such as chips or compact buttons."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-quarter of the base unit.",
+              "when": "Use for small components such as chips or compact buttons."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x}"
+      },
+      {
+        "$value": "0.2rem",
+        "spacingModifier": 0.5,
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished quarter-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "spacingModifier": "{options.space.squish}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished quarter-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish-left-right}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched quarter-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched quarter-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-quarter-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch-left-right}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-eighths of the base unit.",
+            "when": "Use for components needing slightly more padding than quarter-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-eighth-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-eighths of the base unit.",
+              "when": "Use for components needing slightly more padding than quarter-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-eighth-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-eighth-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one-half of the base unit.",
+            "when": "Use for medium-density components such as form inputs or standard buttons."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one-half of the base unit.",
+              "when": "Use for medium-density components such as form inputs or standard buttons."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x}"
+      },
+      {
+        "$value": "0.4rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished half-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished half-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish-top-bottom}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish-left-right}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched half-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched half-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "0.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-half-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch-left-right}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three-quarters of the base unit.",
+            "when": "Use for components needing slightly more padding than half-x."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three-quarters of the base unit.",
+              "when": "Use for components needing slightly more padding than half-x."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x}"
+      },
+      {
+        "$value": "0.6rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished three-quarter-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished three-quarter-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish-top-bottom}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished three-quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished three-quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish-left-right}"
+      },
+      {
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched three-quarter-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched three-quarter-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched three-quarter-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-quarter-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched three-quarter-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-quarter-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch-left-right}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at the base unit.",
+            "when": "Use for standard component padding such as cards or panels."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at the base unit.",
+              "when": "Use for standard component padding such as cards or panels."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x}"
+      },
+      {
+        "$value": "0.8rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished one-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished one-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish-top-bottom}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished one-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished one-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish-left-right}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched one-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched one-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched one-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "1.6rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched one-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch-left-right}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at one and a half times the base unit.",
+            "when": "Use for components needing generous padding such as modals or large cards."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at one and a half times the base unit.",
+              "when": "Use for components needing generous padding such as modals or large cards."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x}"
+      },
+      {
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished one-and-a-half-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished one-and-a-half-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish-top-bottom}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished one-and-a-half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished one-and-a-half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish-left-right}"
+      },
+      {
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched one-and-a-half-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched one-and-a-half-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched one-and-a-half-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "2.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.one-and-a-half-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched one-and-a-half-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.one-and-a-half-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch-left-right}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at two times the base unit.",
+            "when": "Use for spacious layouts such as page sections or large containers."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at two times the base unit.",
+              "when": "Use for spacious layouts such as page sections or large containers."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x}"
+      },
+      {
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished two-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished two-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish-top-bottom}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished two-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished two-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish-left-right}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched two-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched two-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched two-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "3.2rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.two-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched two-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.two-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-two-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch-left-right}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at three times the base unit.",
+            "when": "Use for very spacious layouts or full-width content areas."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at three times the base unit.",
+              "when": "Use for very spacious layouts or full-width content areas."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x}"
+      },
+      {
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished three-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished three-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish-top-bottom}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished three-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished three-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish-left-right}"
+      },
+      {
+        "$value": "7.2rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched three-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched three-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched three-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "4.8rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.three-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched three-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.three-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-three-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch-left-right}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "inset",
+          "description": {
+            "what": "Uniform inset padding at four times the base unit.",
+            "when": "Use for the most spacious layouts such as hero sections."
+          }
+        },
+        "utility-class": true,
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "inset",
+            "description": {
+              "what": "Uniform inset padding at four times the base unit.",
+              "when": "Use for the most spacious layouts such as hero sections."
+            }
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x}"
+      },
+      {
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "spacingModifier": 0.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a squished four-x inset, compressed by the squish modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.squish}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a squished four-x inset, compressed by the squish modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-squish-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish-top-bottom}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a squished four-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a squished four-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-squish-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish-left-right}"
+      },
+      {
+        "$value": "9.6rem",
+        "$type": "dimension",
+        "spacingModifier": 1.5,
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Top and bottom padding component of a stretched four-x inset, expanded by the stretch modifier.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.space.four-x}",
+          "$type": "dimension",
+          "spacingModifier": "{options.space.stretch}",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Top and bottom padding component of a stretched four-x inset, expanded by the stretch modifier.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-stretch-top-bottom",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch-top-bottom}"
+      },
+      {
+        "$value": "6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "spacing",
+          "category": "spacing",
+          "example": "spacing",
+          "description": {
+            "what": "Left and right padding component of a stretched four-x inset.",
+            "when": "Avoid in new work. Use the base inset token instead.",
+            "alternatives": [
+              "6.4rem"
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "64px",
+          "$type": "dimension",
+          "docs": {
+            "type": "spacing",
+            "category": "spacing",
+            "example": "spacing",
+            "description": {
+              "what": "Left and right padding component of a stretched four-x inset.",
+              "when": "Avoid in new work. Use the base inset token instead.",
+              "alternatives": [
+                "{space.inset.four-x}"
+              ]
+            }
+          }
+        },
+        "name": "cdr-space-inset-four-x-stretch-left-right",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch-left-right}"
+      }
+    ]
+  },
+  "web": {
+    "display": [
+      {
+        "$value": "Mixin for screen readers only",
+        "category": "display",
+        "name": "cdr-display-sr-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      },
+      {
+        "$value": "Mixin for screen readers only, but remains focusable",
+        "category": "display",
+        "name": "cdr-display-sr-only-focusable",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "display"
+        }
+      }
+    ],
+    "container": [
+      {
+        "$value": "Mixin for wrapping page content",
+        "category": "container",
+        "name": "cdr-container",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      },
+      {
+        "$value": "Mixin for wrapping page content responsively",
+        "category": "container",
+        "name": "cdr-container-fluid",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container"
+        }
+      }
+    ],
+    "media-query": [
+      {
+        "$value": "Mixin content rendered at extra small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-xs-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at extra small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-xs-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at small breakpoint only",
+        "category": "media-query",
+        "name": "cdr-sm-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at small breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-sm-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below small breakpoint",
+        "category": "media-query",
+        "name": "cdr-sm-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at medium breakpoint only",
+        "category": "media-query",
+        "name": "cdr-md-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at medium breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-md-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below medium breakpoint",
+        "category": "media-query",
+        "name": "cdr-md-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at large breakpoint only",
+        "category": "media-query",
+        "name": "cdr-lg-mq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered at large breakpoint and above",
+        "category": "media-query",
+        "name": "cdr-lg-mq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      },
+      {
+        "$value": "Mixin content rendered below large breakpoint",
+        "category": "media-query",
+        "name": "cdr-lg-mq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "media-query"
+        }
+      }
+    ],
+    "container-query": [
+      {
+        "$value": "Container content rendered at extra small breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-xs-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at extra small breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-xs-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at small breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at small breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below small breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-sm-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at medium breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at medium breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below medium breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-md-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at large breakpoint only with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-only",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered at large breakpoint and above with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-up",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      },
+      {
+        "$value": "Container content rendered below large breakpoint with optional name",
+        "category": "container-query",
+        "name": "cdr-lg-cq-down",
+        "attributes": {
+          "option": false,
+          "deprecated": false,
+          "category": "container-query"
+        }
+      }
+    ],
+    "misc": [
+      {
+        "$value": "Stuart",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.serif-main}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-serif-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "serif-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.serif-brand-font}"
+      },
+      {
+        "$value": "Stuart, \"Stuart fallback\", Georgia, serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-serif",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "serif",
+          "deprecated": false
+        },
+        "key": "{font.family.serif}"
+      },
+      {
+        "$value": "Graphik",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.sans-main}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-sans-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "sans-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.sans-brand-font}"
+      },
+      {
+        "$value": "Graphik, \"Graphik fallback\", \"Helvetica Neue\", sans-serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-sans",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "sans",
+          "deprecated": false
+        },
+        "key": "{font.family.sans}"
+      },
+      {
+        "$value": "Pressura,  \"Avenir Next\", Roboto, sans-serif",
+        "docs": {
+          "type": "font-family"
+        },
+        "filePath": "tokens/web/font.json",
+        "isSource": false,
+        "original": {
+          "$value": "{options.font.family.mono-rounded}",
+          "docs": {
+            "type": "font-family"
+          }
+        },
+        "name": "cdr-font-family-mono-brand-font",
+        "attributes": {
+          "category": "font",
+          "type": "family",
+          "item": "mono-brand-font",
+          "deprecated": false
+        },
+        "key": "{font.family.mono-brand-font}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-default-family",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-default.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-default-style",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-default.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-default-weight",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-default.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-default-letter-spacing",
+        "attributes": {
+          "category": "text-default",
+          "type": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-default.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-default-size",
+        "attributes": {
+          "category": "text-default",
+          "type": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-default.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-default-line-height",
+        "attributes": {
+          "category": "text-default",
+          "type": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-default.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-eyebrow-100-family",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-eyebrow-100-style",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-eyebrow-100-weight",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looser}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-eyebrow-100-letter-spacing",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-eyebrow-100-size",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-eyebrow-100-line-height",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "uppercase",
+        "$type": "textTransform",
+        "original": {
+          "$value": "uppercase",
+          "$type": "textTransform"
+        },
+        "name": "cdr-text-eyebrow-100-transform",
+        "attributes": {
+          "category": "text-eyebrow",
+          "type": "100",
+          "item": "textTransform",
+          "deprecated": false
+        },
+        "key": "{text-eyebrow.100.textTransform}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-300-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-300-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-300-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looseish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-300-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-300-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-300-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-400-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-400-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-400-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-400-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-400-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-400-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-500-family",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-500-style",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-500-weight",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-500-letter-spacing",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-500-size",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-500-line-height",
+        "attributes": {
+          "category": "text-body",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-300-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-300-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-300-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.looseish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-300-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-300-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-400-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-400-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-400-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-400-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-400-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-body-strong-500-family",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-body-strong-500-style",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-body-strong-500-weight",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-body-strong-500-size",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-body-strong-500-line-height",
+        "attributes": {
+          "category": "text-body-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-body-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-200-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-200-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-200-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-200-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-200-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-300-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-300-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-300-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-300-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-300-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-400-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-400-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-400-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-400-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-400-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-500-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-500-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-500-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-500-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-500-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-sans-600-family",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-sans-600-style",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-sans-600-weight",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-sans-600-size",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-sans-600-line-height",
+        "attributes": {
+          "category": "text-heading-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-200-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-200-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-200-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-200-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-200-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-300-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-300-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-300-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-300-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-300-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-400-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-400-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-400-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-400-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-400-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-500-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-500-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-500-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-500-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-500-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-600-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-600-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-600-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-600-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-600-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-700-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-700-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-700-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-700-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-700-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "32",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.900}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-700-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-800-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-800-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-800-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-800-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-800-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-900-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-900-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-900-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-900-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "44",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-900-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1000-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1000-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1000-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1000-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "50",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1000-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1100-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1100-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1100-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1100-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "56",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1100-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-1200-family",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-1200-style",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-1200-weight",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-1200-size",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-1200-line-height",
+        "attributes": {
+          "category": "text-heading-serif",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-600-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-600-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-600-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-600-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-600-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-700-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-700-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-700-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-700-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "32",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.900}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-700-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-800-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-800-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-800-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-800-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-800-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-900-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-900-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-900-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-900-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "44",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-900-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "50",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1000-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "56",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1100-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-family",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-style",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-weight",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-size",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-serif-strong-1200-line-height",
+        "attributes": {
+          "category": "text-heading-serif-strong",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-serif-strong.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-800-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-800-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-800-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-800-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-800-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-800-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-900-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-900-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-900-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-900-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.900}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-900-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-900-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "900",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.900.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1000-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1000-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1000-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1000-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1000}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1000-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "48",
+        "$type": "number",
+        "original": {
+          "$value": "48px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1000-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1000",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1000.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1100-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1100-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1100-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1100-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "4.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1100-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "52",
+        "$type": "number",
+        "original": {
+          "$value": "52px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1100-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1200-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1200-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1200-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1200-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "5.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1200-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "60",
+        "$type": "number",
+        "original": {
+          "$value": "60px",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1200-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1300-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1300-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1300-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1300-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1300-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "64",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1300-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1400-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1400-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1400-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1400-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "6.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1400-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "72",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1400-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1500-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1500-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1500-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1500-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "7.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1500-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "80",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1700}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1500-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-heading-display-1600-family",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-heading-display-1600-style",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-heading-display-1600-weight",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1600-letter-spacing",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "8.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.1600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-heading-display-1600-size",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "92",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-heading-display-1600-line-height",
+        "attributes": {
+          "category": "text-heading-display",
+          "type": "1600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-heading-display.1600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-300-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-300-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-300-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-300-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "20",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.300}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-300-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-400-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-400-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-400-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-400-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-400-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-500-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-500-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-500-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-500-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-500-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-subheading-sans-600-family",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-subheading-sans-600-style",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "500",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.medium}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-subheading-sans-600-weight",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "0",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.normal}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-subheading-sans-600-size",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-subheading-sans-600-line-height",
+        "attributes": {
+          "category": "text-subheading-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-subheading-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-100-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-100-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-100-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-100-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-100-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "16",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-100-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-200-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-200-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-200-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-200-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-200-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-300-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-300-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-300-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-300-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-300-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-400-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-400-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-400-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-400-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-400-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-500-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-500-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-500-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-500-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-500-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-600-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-600-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-600-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-600-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-600-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-700-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-700-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-700-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-700-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-700-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-800-family",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-800-style",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-800-weight",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.064rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightest}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-800-size",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-800-line-height",
+        "attributes": {
+          "category": "text-utility-sans",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-100-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-100-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-100-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-100-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.100}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-100-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "16",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-100-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "100",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.100.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-200-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-200-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-200-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-200-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-200-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-300-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-300-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-300-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-300-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-300-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-400-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-400-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-400-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-400-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-400-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-500-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-500-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-500-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-500-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-500-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-600-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-600-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-600-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-600-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-600-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-700-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-700-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-700-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-700-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-700-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Graphik, '\"Graphik fallback\"', '\"Helvetica Neue\"', sans-serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.sans}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-sans-strong-800-family",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-sans-strong-800-style",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-sans-strong-800-weight",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-sans-strong-800-size",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-sans-strong-800-line-height",
+        "attributes": {
+          "category": "text-utility-sans-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-sans-strong.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-200-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-200-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-200-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-200-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-200-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-300-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-300-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-300-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-300-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-300-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-400-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-400-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-400-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-400-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-400-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-500-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-500-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-500-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-500-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-500-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-600-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-600-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-600-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-600-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-600-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-700-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-700-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-700-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-700-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-700-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-800-family",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-800-style",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "400",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.normal}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-800-weight",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.032rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tighter}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-800-size",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-800-line-height",
+        "attributes": {
+          "category": "text-utility-serif",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif.800.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-200-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-200-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-200-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-200-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.200}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-200-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "18",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.200}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-200-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "200",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.200.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-300-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-300-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-300-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-300-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.6rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.300}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-300-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "22",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.400}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-300-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "300",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.300.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-400-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-400-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-400-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-400-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "1.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.400}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-400-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "24",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.500}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-400-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "400",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.400.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-500-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-500-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-500-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.008rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tightish}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-500-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.500}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-500-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "26",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.600}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-500-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "500",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.500.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-600-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-600-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-600-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-600-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.4rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.600}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-600-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "30",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.800}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-600-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "600",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.600.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-700-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-700-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-700-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-700-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "2.8rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.700}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-700-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "36",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1000}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-700-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "700",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.700.lineHeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "Stuart, '\"Stuart fallback\"', Georgia, serif",
+        "$type": "fontFamily",
+        "original": {
+          "$value": "{options.font.family.serif}",
+          "$type": "fontFamily"
+        },
+        "name": "cdr-text-utility-serif-strong-800-family",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontFamily",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontFamily}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "normal",
+        "$type": "fontStyle",
+        "original": {
+          "$value": "{options.font.style.normal}",
+          "$type": "fontStyle"
+        },
+        "name": "cdr-text-utility-serif-strong-800-style",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontStyle",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontStyle}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "600",
+        "$type": "fontWeight",
+        "original": {
+          "$value": "{options.font.weight.semibold}",
+          "$type": "fontWeight"
+        },
+        "name": "cdr-text-utility-serif-strong-800-weight",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontWeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontWeight}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "-0.016rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.spacing.tight}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-800-letter-spacing",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "letterSpacing",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.letterSpacing}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "3.2rem",
+        "$type": "dimension",
+        "original": {
+          "$value": "{options.font.size.800}",
+          "$type": "dimension"
+        },
+        "name": "cdr-text-utility-serif-strong-800-size",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "fontSize",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.fontSize}"
+      },
+      {
+        "filePath": "tokens/web/typography.json",
+        "isSource": false,
+        "$value": "40",
+        "$type": "number",
+        "original": {
+          "$value": "{options.font.height.1100}",
+          "$type": "number"
+        },
+        "name": "cdr-text-utility-serif-strong-800-line-height",
+        "attributes": {
+          "category": "text-utility-serif-strong",
+          "type": "800",
+          "item": "lineHeight",
+          "deprecated": false
+        },
+        "key": "{text-utility-serif-strong.800.lineHeight}"
+      }
+    ],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [
+      {
+        "$value": "0 0 0 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.flat-x.$value} {prominence.flat-y.$value} {prominence.flat-blur.$value} {prominence.flat-spread.$value} {prominence.flat-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-flat",
+        "attributes": {
+          "category": "prominence",
+          "type": "flat",
+          "deprecated": false
+        },
+        "key": "{prominence.flat}"
+      },
+      {
+        "$value": "0 0.2rem 0.2rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.raised-x.$value} {prominence.raised-y.$value} {prominence.raised-blur.$value} {prominence.raised-spread.$value} {prominence.raised-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-raised",
+        "attributes": {
+          "category": "prominence",
+          "type": "raised",
+          "deprecated": false
+        },
+        "key": "{prominence.raised}"
+      },
+      {
+        "$value": "0 0.4rem 0.4rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.elevated-x.$value} {prominence.elevated-y.$value} {prominence.elevated-blur.$value} {prominence.elevated-spread.$value} {prominence.elevated-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-elevated",
+        "attributes": {
+          "category": "prominence",
+          "type": "elevated",
+          "deprecated": false
+        },
+        "key": "{prominence.elevated}"
+      },
+      {
+        "$value": "0 0.8rem 0.8rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.floating-x.$value} {prominence.floating-y.$value} {prominence.floating-blur.$value} {prominence.floating-spread.$value} {prominence.floating-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-floating",
+        "attributes": {
+          "category": "prominence",
+          "type": "floating",
+          "deprecated": false
+        },
+        "key": "{prominence.floating}"
+      },
+      {
+        "$value": "0 1.6rem 1.6rem 0 rgba(46, 46, 43, 0.2)",
+        "docs": {
+          "type": "prominence",
+          "category": "prominence",
+          "example": "prominence"
+        },
+        "filePath": "tokens/web/prominence.json",
+        "isSource": false,
+        "original": {
+          "$value": "{prominence.lifted-x.$value} {prominence.lifted-y.$value} {prominence.lifted-blur.$value} {prominence.lifted-spread.$value} {prominence.lifted-color.$value}",
+          "docs": {
+            "type": "prominence",
+            "category": "prominence",
+            "example": "prominence"
+          }
+        },
+        "name": "cdr-prominence-lifted",
+        "attributes": {
+          "category": "prominence",
+          "type": "lifted",
+          "deprecated": false
+        },
+        "key": "{prominence.lifted}"
+      }
+    ],
+    "radius": [],
+    "spacing": [
+      {
+        "$value": "0 0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.eighth-x-squish-top-bottom.$value} {space.inset.eighth-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "eighth-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-squish}"
+      },
+      {
+        "$value": "0.4rem 0.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.eighth-x-stretch-top-bottom.$value} {space.inset.eighth-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-eighth-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "eighth-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.eighth-x-stretch}"
+      },
+      {
+        "$value": "0.2rem 0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.quarter-x-squish-top-bottom.$value} {space.inset.quarter-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "quarter-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-squish}"
+      },
+      {
+        "$value": "0.6rem 0.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.quarter-x-stretch-top-bottom.$value} {space.inset.quarter-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-quarter-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "quarter-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.quarter-x-stretch}"
+      },
+      {
+        "$value": "0.4rem 0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.half-x-squish-top-bottom.$value} {space.inset.half-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "half-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-squish}"
+      },
+      {
+        "$value": "1.2rem 0.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.half-x-stretch-top-bottom.$value} {space.inset.half-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-half-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "half-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.half-x-stretch}"
+      },
+      {
+        "$value": "0.6rem 1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-quarter-x-squish-top-bottom.$value} {space.inset.three-quarter-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-quarter-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-squish}"
+      },
+      {
+        "$value": "1.8rem 1.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-quarter-x-stretch-top-bottom.$value} {space.inset.three-quarter-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-quarter-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-quarter-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-quarter-x-stretch}"
+      },
+      {
+        "$value": "0.8rem 1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-x-squish-top-bottom.$value} {space.inset.one-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-squish}"
+      },
+      {
+        "$value": "2.4rem 1.6rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-x-stretch-top-bottom.$value} {space.inset.one-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-x-stretch}"
+      },
+      {
+        "$value": "1.2rem 2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-and-a-half-x-squish-top-bottom.$value} {space.inset.one-and-a-half-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-and-a-half-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-squish}"
+      },
+      {
+        "$value": "3.6rem 2.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.one-and-a-half-x-stretch-top-bottom.$value} {space.inset.one-and-a-half-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-one-and-a-half-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "one-and-a-half-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.one-and-a-half-x-stretch}"
+      },
+      {
+        "$value": "1.6rem 3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.two-x-squish-top-bottom.$value} {space.inset.two-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "two-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-squish}"
+      },
+      {
+        "$value": "4.8rem 3.2rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.two-x-stretch-top-bottom.$value} {space.inset.two-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-two-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "two-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.two-x-stretch}"
+      },
+      {
+        "$value": "2.4rem 4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-x-squish-top-bottom.$value} {space.inset.three-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-squish}"
+      },
+      {
+        "$value": "7.2rem 4.8rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.three-x-stretch-top-bottom.$value} {space.inset.three-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-three-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "three-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.three-x-stretch}"
+      },
+      {
+        "$value": "3.2rem 6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.four-x-squish-top-bottom.$value} {space.inset.four-x-squish-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x-squish",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "four-x-squish",
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-squish}"
+      },
+      {
+        "$value": "9.6rem 6.4rem",
+        "$type": "dimension",
+        "docs": {
+          "type": "inset",
+          "category": "spacing",
+          "example": "spacing"
+        },
+        "utility-class": true,
+        "filePath": "tokens/web/space.json",
+        "isSource": false,
+        "original": {
+          "$value": "{space.inset.four-x-stretch-top-bottom.$value} {space.inset.four-x-stretch-left-right.$value}",
+          "$type": "dimension",
+          "docs": {
+            "type": "inset",
+            "category": "spacing",
+            "example": "spacing"
+          },
+          "utility-class": true
+        },
+        "name": "cdr-space-inset-four-x-stretch",
+        "attributes": {
+          "category": "space",
+          "type": "inset",
+          "item": "four-x-stretch",
+          "deprecated": false
+        },
+        "key": "{space.inset.four-x-stretch}"
+      }
+    ],
+    "breakpoints": [
+      {
+        "$value": "0",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "0",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-xs",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "xs",
+          "deprecated": false
+        },
+        "key": "{breakpoint.xs}"
+      },
+      {
+        "$value": "768px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "768px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-sm",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "sm",
+          "deprecated": false
+        },
+        "key": "{breakpoint.sm}"
+      },
+      {
+        "$value": "992px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "992px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-md",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "md",
+          "deprecated": false
+        },
+        "key": "{breakpoint.md}"
+      },
+      {
+        "$value": "1232px",
+        "$type": "breakpoint",
+        "docs": {
+          "type": "breakpoint",
+          "category": "breakpoints",
+          "example": "breakpoint"
+        },
+        "filePath": "tokens/web/breakpoints.json",
+        "isSource": false,
+        "original": {
+          "$value": "1232px",
+          "$type": "breakpoint",
+          "docs": {
+            "type": "breakpoint",
+            "category": "breakpoints",
+            "example": "breakpoint"
+          }
+        },
+        "name": "cdr-breakpoint-lg",
+        "attributes": {
+          "category": "breakpoint",
+          "type": "lg",
+          "deprecated": false
+        },
+        "key": "{breakpoint.lg}"
+      }
+    ],
+    "text": [
+      {
+        "$value": "clamp(2.8rem, 0.55vw + 2.62rem, 3.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.8rem, 0.55vw + 2.62rem, 3.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.1}"
+      },
+      {
+        "$value": "clamp(3.15rem, 0.89vw + 2.87rem, 3.96rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.15rem, 0.89vw + 2.87rem, 3.96rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.2}"
+      },
+      {
+        "$value": "clamp(3.54rem, 1.32vw + 3.12rem, 4.75rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.54rem, 1.32vw + 3.12rem, 4.75rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.3}"
+      },
+      {
+        "$value": "clamp(3.99rem, 1.88vw + 3.38rem, 5.7rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.99rem, 1.88vw + 3.38rem, 5.7rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-4",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "4",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.4}"
+      },
+      {
+        "$value": "clamp(4.49rem, 2.59vw + 3.66rem, 6.84rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(4.49rem, 2.59vw + 3.66rem, 6.84rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-5",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "5",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.5}"
+      },
+      {
+        "$value": "clamp(2.8rem, 0.77vw + 2.55rem, 3.5rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.8rem, 0.77vw + 2.55rem, 3.5rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.2}"
+      },
+      {
+        "$value": "clamp(3.3rem, 1.1vw + 2.95rem, 4.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.3rem, 1.1vw + 2.95rem, 4.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.3}"
+      },
+      {
+        "$value": "clamp(3.9rem, 1.53vw + 3.41rem, 5.3rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.9rem, 1.53vw + 3.41rem, 5.3rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-4",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "4",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.4}"
+      },
+      {
+        "$value": "clamp(4.6rem, 2.1vw + 3.93rem, 6.51rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(4.6rem, 2.1vw + 3.93rem, 6.51rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-5",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "5",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.5}"
+      },
+      {
+        "$value": "clamp(5.43rem, 2.83vw + 4.52rem, 8.01rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(5.43rem, 2.83vw + 4.52rem, 8.01rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-6",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "6",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.6}"
+      },
+      {
+        "$value": "clamp(6.41rem, 3.78vw + 5.2rem, 9.85rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(6.41rem, 3.78vw + 5.2rem, 9.85rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-heading-display-7",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "heading",
+          "subitem": "display",
+          "state": "7",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.heading.display.7}"
+      },
+      {
+        "$value": "clamp(2.2rem, 0.44vw + 2.06rem, 2.6rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.2rem, 0.44vw + 2.06rem, 2.6rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.0}"
+      },
+      {
+        "$value": "clamp(2.57rem, 0.6vw + 2.38rem, 3.12rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.57rem, 0.6vw + 2.38rem, 3.12rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.1}"
+      },
+      {
+        "$value": "clamp(3.01rem, 0.8vw + 2.75rem, 3.74rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.01rem, 0.8vw + 2.75rem, 3.74rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-subheading-sans-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "subheading",
+          "subitem": "sans",
+          "state": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.subheading.sans.2}"
+      },
+      {
+        "$value": "clamp(3rem, 0.44vw + 2.86rem, 3.4rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3rem, 0.44vw + 2.86rem, 3.4rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-body-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "body",
+          "subitem": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.body.0}"
+      },
+      {
+        "$value": "clamp(3.4rem, 0.55vw + 3.23rem, 3.91rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.4rem, 0.55vw + 3.23rem, 3.91rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-body-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "body",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.body.1}"
+      },
+      {
+        "$value": "clamp(2.2rem, 0.4386vw + 2.05965rem, 2.6rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.2rem, 0.4386vw + 2.05965rem, 2.6rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-0",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "0",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.0}"
+      },
+      {
+        "$value": "clamp(2.552rem, 0.62281vw + 2.3527rem, 3.12rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.552rem, 0.62281vw + 2.3527rem, 3.12rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.1}"
+      },
+      {
+        "$value": "clamp(2.96032rem, 0.8593vw + 2.68534rem, 3.744rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(2.96032rem, 0.8593vw + 2.68534rem, 3.744rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-2",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.2}"
+      },
+      {
+        "$value": "clamp(3.43397rem, 1.161vw + 3.06245rem, 4.4928rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(3.43397rem, 1.161vw + 3.06245rem, 4.4928rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-3",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "3",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.3}"
+      },
+      {
+        "$value": "clamp(1.89655rem, 0.29618vw + 1.80177rem, 2.16667rem)",
+        "type": "clamp",
+        "docs": {
+          "type": "fluid line height",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/line-height.json",
+        "isSource": false,
+        "original": {
+          "$value": "clamp(1.89655rem, 0.29618vw + 1.80177rem, 2.16667rem)",
+          "type": "clamp",
+          "docs": {
+            "type": "fluid line height",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-line-height-ratio-utility-minus-1",
+        "attributes": {
+          "category": "line-height",
+          "type": "ratio",
+          "item": "utility",
+          "subitem": "minus-1",
+          "deprecated": false
+        },
+        "key": "{line-height.ratio.utility.minus-1}"
+      },
+      {
+        "$value": "clamp(1.6rem, 0.44cqw + 1.46rem, 2rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.6rem",
+            "ideal": "0.44cqw + 1.46rem",
+            "max": "2rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-0",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "0",
+          "deprecated": false
+        },
+        "key": "{type.scale.0}"
+      },
+      {
+        "$value": "clamp(1.92rem, 0.64cqw + 1.72rem, 2.5rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.92rem",
+            "ideal": "0.64cqw + 1.72rem",
+            "max": "2.5rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-1",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "1",
+          "deprecated": false
+        },
+        "key": "{type.scale.1}"
+      },
+      {
+        "$value": "clamp(2.3rem, 0.9cqw + 2.02rem, 3.13rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.3rem",
+            "ideal": "0.9cqw + 2.02rem",
+            "max": "3.13rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-2",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "2",
+          "deprecated": false
+        },
+        "key": "{type.scale.2}"
+      },
+      {
+        "$value": "clamp(2.76rem, 1.25cqw + 2.36rem, 3.91rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "2.76rem",
+            "ideal": "1.25cqw + 2.36rem",
+            "max": "3.91rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-3",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "3",
+          "deprecated": false
+        },
+        "key": "{type.scale.3}"
+      },
+      {
+        "$value": "clamp(3.32rem, 1.72cqw + 2.77rem, 4.88rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.32rem",
+            "ideal": "1.72cqw + 2.77rem",
+            "max": "4.88rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-4",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "4",
+          "deprecated": false
+        },
+        "key": "{type.scale.4}"
+      },
+      {
+        "$value": "clamp(3.98rem, 2.33cqw + 3.24rem, 6.1rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "3.98rem",
+            "ideal": "2.33cqw + 3.24rem",
+            "max": "6.1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-5",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "5",
+          "deprecated": false
+        },
+        "key": "{type.scale.5}"
+      },
+      {
+        "$value": "clamp(4.78rem, 3.13cqw + 3.78rem, 7.63rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "4.78rem",
+            "ideal": "3.13cqw + 3.78rem",
+            "max": "7.63rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-6",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "6",
+          "deprecated": false
+        },
+        "key": "{type.scale.6}"
+      },
+      {
+        "$value": "clamp(5.73rem, 4.17cqw + 4.4rem, 9.54rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "5.73rem",
+            "ideal": "4.17cqw + 4.4rem",
+            "max": "9.54rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-7",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "7",
+          "deprecated": false
+        },
+        "key": "{type.scale.7}"
+      },
+      {
+        "$value": "clamp(1.33rem, 0.29cqw + 1.24rem, 1.6rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.33rem",
+            "ideal": "0.29cqw + 1.24rem",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-minus-1",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "minus",
+          "subitem": "1",
+          "deprecated": false
+        },
+        "key": "{type.scale.minus.1}"
+      },
+      {
+        "$value": "clamp(1.3rem, 0.29cqw + 1.24rem, 1.4rem)",
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid type scale",
+          "category": "text",
+          "example": "clamp"
+        },
+        "filePath": "tokens/web/types.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "1.3rem",
+            "ideal": "0.29cqw + 1.24rem",
+            "max": "1.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid type scale",
+            "category": "text",
+            "example": "clamp"
+          }
+        },
+        "name": "cdr-type-scale-minus-2",
+        "attributes": {
+          "category": "type",
+          "type": "scale",
+          "item": "minus",
+          "subitem": "2",
+          "deprecated": false
+        },
+        "key": "{type.scale.minus.2}"
+      }
+    ]
+  },
+  "android": {
+    "misc": [],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [],
+    "radius": [],
+    "spacing": [],
+    "breakpoints": [],
+    "text": [
+      {
+        "$value": "34.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "34px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.size}"
+      },
+      {
+        "$value": "40.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Medium.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Medium.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_display1_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.font-family}"
+      },
+      {
+        "$value": "26.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "26px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.size}"
+      },
+      {
+        "$value": "36.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "36px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title1_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.font-family}"
+      },
+      {
+        "$value": "24.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.size}"
+      },
+      {
+        "$value": "32.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title2_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.font-family}"
+      },
+      {
+        "$value": "19.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "19px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.size}"
+      },
+      {
+        "$value": "28.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "28px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_title3_font_family",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.font-family}"
+      },
+      {
+        "$value": "17.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "17px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_headline_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.size}"
+      },
+      {
+        "$value": "24.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_headline_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_subheadline_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.size}"
+      },
+      {
+        "$value": "20.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_subheadline_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.size}"
+      },
+      {
+        "$value": "20.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.line-spacing}"
+      },
+      {
+        "$value": "12.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.size}"
+      },
+      {
+        "$value": "18.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "18px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_body2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.line-spacing}"
+      },
+      {
+        "$value": "12.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption1_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.size}"
+      },
+      {
+        "$value": "16.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption1_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.line-spacing}"
+      },
+      {
+        "$value": "11.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "11px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption2_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.size}"
+      },
+      {
+        "$value": "16.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_caption2_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.line-spacing}"
+      },
+      {
+        "$value": "15.00sp",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_button_size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.size}"
+      },
+      {
+        "$value": "24.00dp",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "cdr_text_default_button_line_spacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.line-spacing}"
+      }
+    ]
+  },
+  "ios": {
+    "misc": [],
+    "colors": [],
+    "color": [],
+    "form": [],
+    "icon": [],
+    "motion": [],
+    "prominence": [],
+    "radius": [],
+    "spacing": [
+      {
+        "$value": {
+          "min": "0.2rem",
+          "ideal": "0.1rem + 0.223cqi",
+          "max": "0.4rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+            "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+            "alternatives": [
+              {
+                "min": "0.2rem",
+                "ideal": "0.2rem + 0.11cqi",
+                "max": "0.3rem"
+              },
+              {
+                "min": "0.3rem",
+                "ideal": "0.3rem + 0.11cqi",
+                "max": "0.4rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.2rem",
+            "ideal": "0.1rem + 0.223cqi",
+            "max": "0.4rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 0 to 1, scaling from 3.2px to 6.4px.",
+              "when": "Use when spacing needs to adapt across the range of the two smallest steps.",
+              "alternatives": [
+                "{space.scale.0}",
+                "{space.scale.1}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale01",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.0--1}"
+      },
+      {
+        "$value": {
+          "min": "0.4rem",
+          "ideal": "0.2rem + 0.66cqi",
+          "max": "1rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+            "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+            "alternatives": [
+              {
+                "min": "0.8rem",
+                "ideal": "0.7rem + 0.22cqi",
+                "max": "1rem"
+              },
+              {
+                "min": "1.2rem",
+                "ideal": "1.1rem + 0.33cqi",
+                "max": "1.5rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.4rem",
+            "ideal": "0.2rem + 0.66cqi",
+            "max": "1rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 4, scaling from 6.4px to 16px.",
+              "when": "Use when spacing needs to adapt broadly between component and section spacing.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale34",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--4}"
+      },
+      {
+        "$value": {
+          "min": "0.8rem",
+          "ideal": "0.1404px + 1.21cqi",
+          "max": "1.6rem"
+        },
+        "$type": "clamp",
+        "docs": {
+          "type": "fluid space",
+          "category": "spacing",
+          "example": "clamp",
+          "description": {
+            "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+            "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+            "alternatives": [
+              {
+                "min": "0.8rem",
+                "ideal": "0.7rem + 0.22cqi",
+                "max": "1rem"
+              },
+              {
+                "min": "1.2rem",
+                "ideal": "1.1rem + 0.33cqi",
+                "max": "1.5rem"
+              },
+              {
+                "min": "1.6rem",
+                "ideal": "1.5rem + 0.44cqi",
+                "max": "2rem"
+              }
+            ]
+          }
+        },
+        "filePath": "tokens/global/space.json",
+        "isSource": false,
+        "original": {
+          "$value": {
+            "min": "0.8rem",
+            "ideal": "0.1404px + 1.21cqi",
+            "max": "1.6rem"
+          },
+          "$type": "clamp",
+          "docs": {
+            "type": "fluid space",
+            "category": "spacing",
+            "example": "clamp",
+            "description": {
+              "what": "Fluid spacing spanning steps 3 to 5, scaling from 12.8px to 25.6px.",
+              "when": "Use when spacing needs to adapt across a wide range of container sizes.",
+              "alternatives": [
+                "{space.scale.3}",
+                "{space.scale.4}",
+                "{space.scale.5}"
+              ]
+            }
+          }
+        },
+        "name": "CdrSpaceScale35",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{space.scale.3--5}"
+      }
+    ],
+    "breakpoints": [],
+    "text": [
+      {
+        "$value": "34.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "34px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.size}"
+      },
+      {
+        "$value": "40.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "40px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Medium.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Display 1",
+          "ios": "Large Title",
+          "description": "Suggested Usage: Frequently used as the largest title for phone apps and can be used for page titles for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Medium.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.display1.docCategory}",
+            "type": "{text.default.display1.docType}",
+            "android": "{text.default.display1.docAndroid}",
+            "ios": "{text.default.display1.docIos}",
+            "description": "{text.default.display1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultDisplay1FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.display1.font-family}"
+      },
+      {
+        "$value": "26.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "26px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.size}"
+      },
+      {
+        "$value": "36.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "36px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 1",
+          "ios": "Title 1",
+          "description": "Suggested Usage: Content titles, level 1"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title1.docCategory}",
+            "type": "{text.default.title1.docType}",
+            "android": "{text.default.title1.docAndroid}",
+            "ios": "{text.default.title1.docIos}",
+            "description": "{text.default.title1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle1FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title1.font-family}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.size}"
+      },
+      {
+        "$value": "32.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "32px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 2",
+          "ios": "Title 2",
+          "description": "Suggested Usage: Content titles, product names, level 2"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title2.docCategory}",
+            "type": "{text.default.title2.docType}",
+            "android": "{text.default.title2.docAndroid}",
+            "ios": "{text.default.title2.docIos}",
+            "description": "{text.default.title2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle2FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title2.font-family}"
+      },
+      {
+        "$value": "19.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "19px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.size}"
+      },
+      {
+        "$value": "28.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "28px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.line-spacing}"
+      },
+      {
+        "$value": "Stuart-App-Semibold.otf",
+        "property": "font-family",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Title 3",
+          "ios": "Title 3",
+          "description": "Suggested Usage: Content titles, product names, product prices, level 3"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "Stuart-App-Semibold.otf",
+          "property": "font-family",
+          "docs": {
+            "category": "{text.default.title3.docCategory}",
+            "type": "{text.default.title3.docType}",
+            "android": "{text.default.title3.docAndroid}",
+            "ios": "{text.default.title3.docIos}",
+            "description": "{text.default.title3.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultTitle3FontFamily",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.title3.font-family}"
+      },
+      {
+        "$value": "17.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "17px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultHeadlineSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.size}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Headline",
+          "ios": "Headline",
+          "description": "Suggested Usage: Heading primarily used with body copy, list items, table headers"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.headline.docCategory}",
+            "type": "{text.default.headline.docType}",
+            "android": "{text.default.headline.docAndroid}",
+            "ios": "{text.default.headline.docIos}",
+            "description": "{text.default.headline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultHeadlineLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.headline.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultSubheadlineSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.size}"
+      },
+      {
+        "$value": "20.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "header",
+          "android": "Subhead",
+          "ios": "Subhead",
+          "description": "Suggested Usage: Subheading primarily used with body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.subheadline.docCategory}",
+            "type": "{text.default.subheadline.docType}",
+            "android": "{text.default.subheadline.docAndroid}",
+            "ios": "{text.default.subheadline.docIos}",
+            "description": "{text.default.subheadline.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultSubheadlineLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.subheadline.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.size}"
+      },
+      {
+        "$value": "20.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 1",
+          "ios": "Body",
+          "description": "Suggested Usage: Default for body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "20px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body1.docCategory}",
+            "type": "{text.default.body1.docType}",
+            "android": "{text.default.body1.docAndroid}",
+            "ios": "{text.default.body1.docIos}",
+            "description": "{text.default.body1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body1.line-spacing}"
+      },
+      {
+        "$value": "12.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.size}"
+      },
+      {
+        "$value": "18.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Body 2",
+          "ios": "Footnote",
+          "description": "Suggested Usage: Secondary text intended for informational and supplemental body content"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "18px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.body2.docCategory}",
+            "type": "{text.default.body2.docType}",
+            "android": "{text.default.body2.docAndroid}",
+            "ios": "{text.default.body2.docIos}",
+            "description": "{text.default.body2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultBody2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.body2.line-spacing}"
+      },
+      {
+        "$value": "12.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "12px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption1Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.size}"
+      },
+      {
+        "$value": "16.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 1",
+          "ios": "Caption 1",
+          "description": "Suggested Usage: Tertiary text, also intended for informational and supplemental body content. Also used for bottom action bar text for larger devices"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption1.docCategory}",
+            "type": "{text.default.caption1.docType}",
+            "android": "{text.default.caption1.docAndroid}",
+            "ios": "{text.default.caption1.docIos}",
+            "description": "{text.default.caption1.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption1LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption1.line-spacing}"
+      },
+      {
+        "$value": "11.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "11px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption2Size",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.size}"
+      },
+      {
+        "$value": "16.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "body",
+          "android": "Caption 2",
+          "ios": "Caption 2",
+          "description": "Suggested Usage: Smallest text size, use sparingly or for bottom tab bar text"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "16px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.caption2.docCategory}",
+            "type": "{text.default.caption2.docType}",
+            "android": "{text.default.caption2.docAndroid}",
+            "ios": "{text.default.caption2.docIos}",
+            "description": "{text.default.caption2.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultCaption2LineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.caption2.line-spacing}"
+      },
+      {
+        "$value": "15.0f",
+        "$type": "fontSize",
+        "property": "font-size",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "15px",
+          "$type": "fontSize",
+          "property": "font-size",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultButtonSize",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.size}"
+      },
+      {
+        "$value": "24.0f",
+        "$type": "dimension",
+        "property": "line-height",
+        "docs": {
+          "category": "text",
+          "type": "button",
+          "android": "Button",
+          "ios": "N/A",
+          "description": "Suggested Usage: Button text has a thicker weight than body copy"
+        },
+        "filePath": "tokens/mobile/text.json",
+        "isSource": false,
+        "original": {
+          "$value": "24px",
+          "$type": "dimension",
+          "property": "line-height",
+          "docs": {
+            "category": "{text.default.button.docCategory}",
+            "type": "{text.default.button.docType}",
+            "android": "{text.default.button.docAndroid}",
+            "ios": "{text.default.button.docIos}",
+            "description": "{text.default.button.docDescription}"
+          }
+        },
+        "name": "CdrTextDefaultButtonLineSpacing",
+        "attributes": {
+          "deprecated": false
+        },
+        "key": "{text.default.button.line-spacing}"
+      }
+    ]
+  }
+}

--- a/stories/ConsumerTypeScriptContract.stories.ts
+++ b/stories/ConsumerTypeScriptContract.stories.ts
@@ -672,7 +672,7 @@ Are you building tooling, running transforms, or consuming outside JS?
             {
               title: 'App theme mapping — js + semantic root',
               language: 'ts',
-              code: `import { CdrColorText, CdrSpace, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrColorText, CdrSpace, CdrTextSize } from '@rei/cdr-tokens';
 
 export const appTheme = {
   color: {
@@ -682,7 +682,7 @@ export const appTheme = {
     stackMd: CdrSpace.CdrSpaceTwoX,
   },
   type: {
-    headingMd: CdrType.CdrTextHeadingSans400Size,
+    headingMd: CdrTextSize.CdrTextHeadingSans400Size,
   },
 };`,
             },
@@ -760,7 +760,7 @@ export const UsageExamples: Story = {
             {
               title: 'App theme mapping (js + semantic)',
               language: 'ts',
-              code: `import { CdrColorText, CdrSpace, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrColorText, CdrSpace, CdrTextSize } from '@rei/cdr-tokens';
 
 export const appTheme = {
   color: {
@@ -770,25 +770,25 @@ export const appTheme = {
     stackMd: CdrSpace.CdrSpaceTwoX,
   },
   type: {
-    headingMd: CdrType.CdrTextHeadingSans400Size,
+    headingMd: CdrTextSize.CdrTextHeadingSans400Size,
   },
 };`,
             },
             {
               title: 'Map typography into an app contract',
               language: 'ts',
-              code: `import { CdrText, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrTextSize, CdrTextWeight, CdrTextLineHeight } from '@rei/cdr-tokens';
 
 export const textStyles = {
   body: {
-    fontSize: CdrText.CdrTextBody300Size,
-    fontWeight: CdrText.CdrTextBody300Weight,
-    lineHeight: CdrText.CdrTextBody300LineHeight,
+    fontSize: CdrTextSize.CdrTextBody300Size,
+    fontWeight: CdrTextWeight.CdrTextBody300Weight,
+    lineHeight: CdrTextLineHeight.CdrTextBody300LineHeight,
   },
   heading: {
-    fontSize: CdrType.CdrTextHeadingSans400Size,
-    fontWeight: CdrType.CdrTextHeadingSans400Weight,
-    lineHeight: CdrType.CdrTextHeadingSans400LineHeight,
+    fontSize: CdrTextSize.CdrTextHeadingSans400Size,
+    fontWeight: CdrTextWeight.CdrTextHeadingSans400Weight,
+    lineHeight: CdrTextLineHeight.CdrTextHeadingSans400LineHeight,
   },
 };`,
             },
@@ -908,12 +908,12 @@ const color = CdrColorText.CdrColorTextPrimary;`,
             {
               title: 'Semantic root (default)',
               language: 'ts',
-              code: `import { CdrColorText, CdrSpace, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrColorText, CdrSpace, CdrTextSize } from '@rei/cdr-tokens';
 
 const appTheme = {
   textPrimary: CdrColorText.CdrColorTextPrimary,
   spacingMd: CdrSpace.CdrSpaceTwoX,
-  headingMd: CdrType.CdrTextHeadingSans400Size,
+  headingMd: CdrTextSize.CdrTextHeadingSans400Size,
 };`,
             },
             {
@@ -1841,27 +1841,27 @@ export const Js: Story = {
             {
               title: 'Semantic grouped objects (semantic)',
               language: 'ts',
-              code: `import { CdrColorText, CdrSpace, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrColorText, CdrSpace, CdrTextSize } from '@rei/cdr-tokens';
 
 CdrColorText.CdrColorTextPrimary;
 CdrSpace.CdrSpaceOneX;
-CdrType.CdrTextHeadingSans400Size;`,
+CdrTextSize.CdrTextHeadingSans400Size;`,
             },
             {
               title: 'Typography app contract',
               language: 'ts',
-              code: `import { CdrText, CdrType } from '@rei/cdr-tokens';
+              code: `import { CdrTextSize, CdrTextWeight, CdrTextLineHeight } from '@rei/cdr-tokens';
 
 export const textStyles = {
   body: {
-    fontSize: CdrText.CdrTextBody300Size,
-    fontWeight: CdrText.CdrTextBody300Weight,
-    lineHeight: CdrText.CdrTextBody300LineHeight,
+    fontSize: CdrTextSize.CdrTextBody300Size,
+    fontWeight: CdrTextWeight.CdrTextBody300Weight,
+    lineHeight: CdrTextLineHeight.CdrTextBody300LineHeight,
   },
   heading: {
-    fontSize: CdrType.CdrTextHeadingSans400Size,
-    fontWeight: CdrType.CdrTextHeadingSans400Weight,
-    lineHeight: CdrType.CdrTextHeadingSans400LineHeight,
+    fontSize: CdrTextSize.CdrTextHeadingSans400Size,
+    fontWeight: CdrTextWeight.CdrTextHeadingSans400Weight,
+    lineHeight: CdrTextLineHeight.CdrTextHeadingSans400LineHeight,
   },
 };`,
             },

--- a/validate-structure.json
+++ b/validate-structure.json
@@ -1064,6 +1064,12 @@
             },
             {
               "parent": "docsite/json",
+              "path": "docsite/json/platform-tokens.json",
+              "name": "platform-tokens.json",
+              "type": "file"
+            },
+            {
+              "parent": "docsite/json",
               "path": "docsite/json/web.json",
               "name": "web.json",
               "type": "file"
@@ -2888,6 +2894,12 @@
               "parent": "rei-dot-com/json",
               "path": "rei-dot-com/json/ios.json",
               "name": "ios.json",
+              "type": "file"
+            },
+            {
+              "parent": "rei-dot-com/json",
+              "path": "rei-dot-com/json/platform-tokens.json",
+              "name": "platform-tokens.json",
               "type": "file"
             },
             {


### PR DESCRIPTION
Replace incorrect CdrType.CdrTextHeadingSans400* and CdrText.CdrTextBody300* usages with the correct CdrTextSize, CdrTextWeight, and CdrTextLineHeight module accessors. CdrType only exports fluid type scale values (CdrTypeScale*) and CdrText only exports CdrTextEyebrow100Transform.

Also update validate-structure.json snapshot and include built dist artifacts.